### PR TITLE
fix: Use unit regex separate from comment regex

### DIFF
--- a/src/core/parsing/gem5/perl/libs/Scanning/RegexUtils.pm
+++ b/src/core/parsing/gem5/perl/libs/Scanning/RegexUtils.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Exporter 'import';
 
-our @EXPORT_OK = qw($floatRegex $varNameRegex $confValueRegex $scalarValueRegex $commentRegex $complexValueRegex $summariesEntryRegex);
+our @EXPORT_OK = qw($floatRegex $varNameRegex $confValueRegex $scalarValueRegex $commentRegex $unitRegex $complexValueRegex $summariesEntryRegex);
 our %EXPORT_TAGS = (all => \@EXPORT_OK);
 
 # Scientific Quality: Support for negative numbers, scientific notation, and standard floats.
@@ -19,9 +19,10 @@ our $confValueRegex = qr/[\d\.\w\-\/\(\)\,]+/;
 # Scalars are either integers or the scientific-compliant float.
 our $scalarValueRegex = qr/-?\d+|$floatRegex/;
 
-# Comments are whitespace-prefixed and can be # hashes or (Unspecified) tags.
-# Robust against trailing spaces and anchored to end-of-line to prevent backtracking.
-our $commentRegex = qr/\s*(?:#.*|\(Unspecified\)\s*)?$/;
+# Comments start with #
+our $commentRegex = qr/#.*/;
+
+our $unitRegex = qr/\(\w+\)/;
 
 # Complex components (Distributions/Histograms):
 # e.g., "10  5.23%  95.0%"

--- a/src/core/parsing/gem5/perl/libs/Scanning/Type/Distribution.pm
+++ b/src/core/parsing/gem5/perl/libs/Scanning/Type/Distribution.pm
@@ -5,16 +5,16 @@ use warnings;
 use Exporter 'import';
 use Scanning::RegexUtils qw(:all);
 
-our @EXPORT_OK = qw($distRegex $distEntry);
+our @EXPORT_OK = qw($distRegex $distEntryRegex);
 
 # Distribution components regexes
 # | ::5
 my $distEntryNumericRegex = qr/::-?\d+/;
 my $distEntryOverflowRegex = qr/::overflows/;
 my $distEntryUnderflowRegex = qr/::underflows/;
-our $distEntry = qr/($distEntryNumericRegex|$distEntryOverflowRegex|$distEntryUnderflowRegex)/;
+our $distEntryRegex = qr/($distEntryNumericRegex|$distEntryOverflowRegex|$distEntryUnderflowRegex)/;
 
-# | name::distEntryNumRegex  value  perc  cumm.percent  # Comment |
-our $distRegex = qr/^$varNameRegex$distEntry\s+$complexValueRegex$commentRegex$/;
+# | name::distEntryNumRegex  value  perc  cumm.percent  # Comment (unit) |
+our $distRegex = qr/^$varNameRegex$distEntryRegex\s+$complexValueRegex\s*$commentRegex?\s*$unitRegex?$/;
 
 1;

--- a/src/core/parsing/gem5/perl/libs/Scanning/Type/Histogram.pm
+++ b/src/core/parsing/gem5/perl/libs/Scanning/Type/Histogram.pm
@@ -11,7 +11,7 @@ our @EXPORT_OK = qw($histogramRegex $histogramEntryRangeRegex);
 our $histogramEntryRangeRegex = qr/::\d+-\d+/;
 # | ::1-5 |
 
-# | name::range1-range2  value  perc  cumm.percent  # Comment |
-our $histogramRegex = qr/^$varNameRegex$histogramEntryRangeRegex\s+$complexValueRegex$commentRegex$/;
+# | name::range1-range2  value  perc  cumm.percent  # Comment (unit) |
+our $histogramRegex = qr/^$varNameRegex$histogramEntryRangeRegex\s+$complexValueRegex\s*$commentRegex?\s*$unitRegex?$/;
 
 1;

--- a/src/core/parsing/gem5/perl/libs/Scanning/Type/Scalar.pm
+++ b/src/core/parsing/gem5/perl/libs/Scanning/Type/Scalar.pm
@@ -7,7 +7,7 @@ use Scanning::RegexUtils qw(:all);
 
 our @EXPORT_OK = qw($scalarRegex);
 
-# | name  value  comment |
-our $scalarRegex = qr/^$varNameRegex\s+$scalarValueRegex$commentRegex$/;
+# | name  value  comment (unit) |
+our $scalarRegex = qr/^$varNameRegex\s+$scalarValueRegex\s*$commentRegex?\s*$unitRegex?$/;
 
 1;

--- a/src/core/parsing/gem5/perl/libs/Scanning/Type/Summary.pm
+++ b/src/core/parsing/gem5/perl/libs/Scanning/Type/Summary.pm
@@ -7,7 +7,7 @@ use Scanning::RegexUtils qw(:all);
 
 our @EXPORT_OK = qw($summaryRegex);
 
-# | name::summVar  value  # Comment |
-our $summaryRegex = qr/^$varNameRegex$summariesEntryRegex\s+$scalarValueRegex$commentRegex$/;
+# | name::summVar  value  # Comment (unit) |
+our $summaryRegex = qr/^$varNameRegex$summariesEntryRegex\s+$scalarValueRegex\s*$commentRegex?\s*$unitRegex?$/;
 
 1;

--- a/src/core/parsing/gem5/perl/libs/Scanning/Type/Vector.pm
+++ b/src/core/parsing/gem5/perl/libs/Scanning/Type/Vector.pm
@@ -12,9 +12,9 @@ our @EXPORT_OK = qw($vectorRegex $vectorEntryRegex);
 # | ::Name | ::Total
 our $vectorEntryRegex = qr/::[\w\.]+/;
 
-# | name::vectorEntryName  value  perc  cumm.percent  # Comment
+# | name::vectorEntryName  value  perc  cumm.percent  # Comment (unit)
 # OR
-# | name::vectorEntryName  value  # Comment
-our $vectorRegex = qr/^$varNameRegex$vectorEntryRegex\s+(?:$complexValueRegex|$scalarValueRegex)$commentRegex$/;
+# | name::vectorEntryName  value  # Comment (unit)
+our $vectorRegex = qr/^$varNameRegex$vectorEntryRegex\s+(?:$complexValueRegex|$scalarValueRegex)\s*$commentRegex?\s*$unitRegex?$/;
 
 1;

--- a/src/core/parsing/gem5/perl/libs/TypesFormatRegex.pm
+++ b/src/core/parsing/gem5/perl/libs/TypesFormatRegex.pm
@@ -11,7 +11,7 @@ our @EXPORT  = qw(parseAndPrintLineWithFormat setFilterRegexes classifyLine);
 use Scanning::RegexUtils qw(:all);
 use Scanning::Type::Configuration qw($confRegex);
 use Scanning::Type::Scalar qw($scalarRegex);
-use Scanning::Type::Distribution qw($distRegex $distEntry);
+use Scanning::Type::Distribution qw($distRegex $distEntryRegex);
 use Scanning::Type::Histogram qw($histogramRegex $histogramEntryRangeRegex);
 use Scanning::Type::Vector qw($vectorRegex $vectorEntryRegex);
 use Scanning::Type::Summary qw($summaryRegex);
@@ -71,8 +71,8 @@ sub getEntryNameFromLine {
     }
     # If is distribution it is an integer or an
     # overflow/underflow
-    if ($line =~ $distEntry) {
-        $line =~ /($distEntry)/;
+    if ($line =~ $distEntryRegex) {
+        $line =~ /($distEntryRegex)/;
         return $1;
     }
     if ($line =~ $vectorEntryRegex &&
@@ -185,41 +185,32 @@ sub parseAndPrintLineWithFormat {
 sub classifyLine {
     my ($line) = @_;
 
-    # Check types in order with explicit captures
+    my ($name) = $line =~ /^($varNameRegex)/;
 
-    # Configuration: name=value
-    if ($line =~ /^($varNameRegex)=$confValueRegex$/) {
-        return { type => 'configuration', name => $1, entry => undef };
+    # Check types in order with explicit captures
+    if ($line =~ $confRegex) {
+        return { type => 'configuration', name => $name, entry => undef };
     }
-    # Scalar: name value # comment
-    elsif ($line =~ /^($varNameRegex)\s+$scalarValueRegex$commentRegex?$/) {
-        return { type => 'scalar', name => $1, entry => undef };
+    elsif ($line =~ $scalarRegex) {
+        return { type => 'scalar', name => $name, entry => undef };
     }
-    # Histogram: name::range ...
-    elsif ($line =~ /^($varNameRegex)($histogramEntryRangeRegex)\s+$complexValueRegex$commentRegex?$/) {
-        my $name = $1;
-        my $entry = $2;
+    elsif ($line =~ $histogramRegex) {
+        my ($entry) = $line =~ /($histogramEntryRangeRegex)/;
         $entry =~ s/^:://;
         return { type => 'histogram', name => $name, entry => $entry };
     }
-    # Distribution: name::val ...
-    elsif ($line =~ /^($varNameRegex)($distEntry)\s+$complexValueRegex$commentRegex?$/) {
-        my $name = $1;
-        my $entry = $2;
+    elsif ($line =~ $distRegex) {
+        my ($entry) = $line =~ /($distEntryRegex)/;
         $entry =~ s/^:://;
         return { type => 'distribution', name => $name, entry => $entry };
     }
-    # Summary: name::total ...
-    elsif ($line =~ /^($varNameRegex)($summariesEntryRegex)\s+$scalarValueRegex$commentRegex?$/) {
-        my $name = $1;
-        my $entry = $2;
+    elsif ($line =~ $summaryRegex) {
+        my ($entry) = $line =~ /($summariesEntryRegex)/;
         $entry =~ s/^:://;
         return { type => 'summary', name => $name, entry => $entry };
     }
-    # Vector: name::entry ...
-    elsif ($line =~ /^($varNameRegex)($vectorEntryRegex)\s+(?:$complexValueRegex|$scalarValueRegex)$commentRegex?$/) {
-        my $name = $1;
-        my $entry = $2;
+    elsif ($line =~ $vectorRegex) {
+        my ($entry) = $line =~ /($vectorEntryRegex)/;
         $entry =~ s/^:://;
         return { type => 'vector', name => $name, entry => $entry };
     }
@@ -227,4 +218,4 @@ sub classifyLine {
     return undef;
 }
 
-1; # A module must end with a true value or "use" will report an error
+1;

--- a/tests/unit/test_perl_worker_pool.py
+++ b/tests/unit/test_perl_worker_pool.py
@@ -44,6 +44,23 @@ system.mem.readReqs                            500                       # Total
 
 
 @pytest.fixture
+def test_stats_file_unit_without_comment():
+    """Create a stats file where scalar has unit but no comment."""
+    content = """
+---------- Begin Simulation Statistics ----------
+system.cpu.ipc                                   1.500000                       (Tick)
+---------- End Simulation Statistics   ----------
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(content)
+        temp_path = f.name
+
+    yield temp_path
+
+    Path(temp_path).unlink(missing_ok=True)
+
+
+@pytest.fixture
 def perl_exe():
     """Provide perl executable path, ensuring it exists."""
     perl_path = shutil.which("perl")
@@ -143,6 +160,27 @@ class TestPerlWorker:
             assert worker.process.pid != original_pid
             assert worker.is_healthy
             assert worker.restarts == 1
+        finally:
+            worker.shutdown()
+
+    def test_worker_parse_unit_without_comment(
+        self,
+        test_stats_file_unit_without_comment,
+        perl_exe,
+        perl_script_path,
+    ):
+        """Worker should parse scalar lines with unit specifier and no comment."""
+        worker = PerlWorker(worker_id=0, script_path=perl_script_path, perl_exe=perl_exe)
+
+        try:
+            output, success = worker.parse_file(
+                test_stats_file_unit_without_comment,
+                ["system.cpu.ipc"],
+                timeout=10.0,
+            )
+
+            assert success
+            assert "scalar/system.cpu.ipc/1.500000" in output
         finally:
             worker.shutdown()
 


### PR DESCRIPTION
Units were being parsed as part of comments, with this change units are parsed separately. This allows parsing stats that don't have a comment but have a unit specifier.