### PR TITLE
Resolve default-branch CodeQL maintainability findings

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,13 +44,13 @@ def run_app() -> None:
 
     # Initialize Core Components
     from src.core.application_api import ApplicationAPI
-    from src.web.pages.ui.plotting.base_plot import BasePlot
+    from src.web.pages.ui.plotting.plot_factory import PlotFactory
 
     # The API owns mutable data, plots, parser configuration, and operation
     # history. Keep one workspace per browser session; only explicitly
     # thread-safe worker pools are shared process-wide.
     if "api" not in st.session_state:
-        st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+        st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 
     api: ApplicationAPI = st.session_state.api
 

--- a/docs/developer-guide/api-reference/application-api.md
+++ b/docs/developer-guide/api-reference/application-api.md
@@ -34,7 +34,7 @@ Each browser session creates one `ApplicationAPI` and stores it in
 
 ```python
 if "api" not in st.session_state:
-    st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+    st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 api: ApplicationAPI = st.session_state.api
 ```
 
@@ -42,7 +42,7 @@ api: ApplicationAPI = st.session_state.api
 - Mutable data, plots, parser configuration, and history are isolated from
   other browser sessions.
 - Process-wide parser worker pools remain explicitly shared and thread-safe.
-- `BasePlot.from_dict` is injected as the plot deserializer so the core layer never
+- `PlotFactory.from_dict` is injected as the plot deserializer so the core layer never
   imports web-layer classes.
 
 ---
@@ -64,7 +64,7 @@ class ApplicationAPI:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `plot_deserializer` | `PlotDeserializer \| None` | `None` | Callable that converts a `dict` into a `PlotProtocol` instance. Injected into the `RepositoryStateManager` so portfolio restoration can reconstruct plot objects without importing web-layer classes. In production this is `BasePlot.from_dict`. |
+| `plot_deserializer` | `PlotDeserializer \| None` | `None` | Callable that converts a `dict` into a `PlotProtocol` instance. Injected into the `RepositoryStateManager` so portfolio restoration can reconstruct plot objects without importing web-layer classes. In production this is `PlotFactory.from_dict`. |
 | `parser` | `SimulationParser \| None` | `None` | Simulator parser backend. When `None`, defaults to `SimulatorRegistry.get_parser("gem5")`. |
 
 ### Initialization Sequence

--- a/docs/developer-guide/api-reference/state-manager.md
+++ b/docs/developer-guide/api-reference/state-manager.md
@@ -171,7 +171,7 @@ RepositoryStateManager(plot_deserializer: PlotDeserializer | None = None)
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `plot_deserializer` | `PlotDeserializer | None` | Callable that converts a serialized `dict` into a `PlotProtocol` instance. Forwarded to `SessionRepository` so that portfolio restoration never requires importing web-layer classes. At bootstrap, `BasePlot.from_dict` is injected. |
+| `plot_deserializer` | `PlotDeserializer | None` | Callable that converts a serialized `dict` into a `PlotProtocol` instance. Forwarded to `SessionRepository` so that portfolio restoration never requires importing web-layer classes. At bootstrap, `PlotFactory.from_dict` is injected. |
 
 ### Delegation Pattern
 

--- a/docs/developer-guide/architecture/dependency-injection.md
+++ b/docs/developer-guide/architecture/dependency-injection.md
@@ -29,7 +29,7 @@ the current browser session:
 ```python
 # app.py
 if "api" not in st.session_state:
-    st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+    st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 ```
 
 This single call constructs the entire object graph:
@@ -71,7 +71,7 @@ Every downstream layer receives what it needs through this hub:
 
 | Dependency | Injected as | Purpose |
 |---|---|---|
-| `PlotDeserializer` | `BasePlot.from_dict` | Deserialize plot dicts without importing web-layer classes |
+| `PlotDeserializer` | `PlotFactory.from_dict` | Deserialize plot dicts without importing web-layer classes |
 | `SimulationParser` | gem5 parser (default) | Parse simulator output files |
 | `StateManager` | `RepositoryStateManager` instance | Shared application state |
 | `DefaultServicesAPI` | Internal composition | Service facade for managers, data, and shapers |

--- a/docs/developer-guide/architecture/design-patterns.md
+++ b/docs/developer-guide/architecture/design-patterns.md
@@ -205,7 +205,7 @@ layer can deserialize plots from portfolio data without ever importing
 
 ```python
 # app.py:56
-api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 ```
 
 **Design Rationale.**
@@ -420,7 +420,7 @@ under `st.session_state.api`.
 
 ```python
 if "api" not in st.session_state:
-    st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+    st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 api: ApplicationAPI = st.session_state.api
 ```
 
@@ -703,15 +703,16 @@ elif page == "Manage Plots":
 # ...
 ```
 
-`BasePlot.from_dict` imports `PlotFactory` inside the method body to break a
-circular dependency between the base class and its factory:
+`PlotFactory` owns both construction and restoration, so `BasePlot` has no
+reverse dependency on its factory:
 
 ```python
-# src/web/pages/ui/plotting/base_plot.py:205-208
+# src/web/pages/ui/plotting/plot_factory.py
 @classmethod
 def from_dict(cls, data: dict[str, Any]) -> "BasePlot":
-    from .plot_factory import PlotFactory
-    plot = PlotFactory.create_plot(plot_type=data["plot_type"], ...)
+    plot = cls.create_plot(plot_type=data["plot_type"], ...)
+    plot.config = data.get("config", {})
+    return plot
 ```
 
 `StrategyFactory.create()` similarly defers imports of concrete strategies:

--- a/docs/developer-guide/architecture/overview.md
+++ b/docs/developer-guide/architecture/overview.md
@@ -105,7 +105,7 @@ context warnings.
 1. `st.set_page_config(layout="wide")` configures the Streamlit page.
 2. `ApplicationAPI` is created lazily under `st.session_state.api`, giving each
    browser session its own mutable workspace.
-3. `BasePlot.from_dict` is injected as `plot_deserializer` -- this is how Core
+3. `PlotFactory.from_dict` is injected as `plot_deserializer` -- this is how Core
    can deserialize plot dicts back into Web-layer `BasePlot` instances without
    ever importing from Web.
 4. Every page receives that session's API instance through dependency injection.

--- a/docs/developer-guide/web/portfolio-system.md
+++ b/docs/developer-guide/web/portfolio-system.md
@@ -285,7 +285,7 @@ domains in a fixed order:
    If the CSV is empty (config-only portfolio), data is left unset.
    If parsing fails, the error is logged and the session continues without data.
 4. **Plots** -- each plot dict is deserialized via the injected `PlotDeserializer`
-   callable (`BasePlot.from_dict` in production).  Failed plots are logged and
+   callable (`PlotFactory.from_dict` in production).  Failed plots are logged and
    skipped.  The plot counter defaults to the count of successfully loaded plots
    if absent from the portfolio.
 5. **History** -- `manager_history` and `portfolio_history` are written to the

--- a/docs/developer-guide/web/streamlit-best-practices.md
+++ b/docs/developer-guide/web/streamlit-best-practices.md
@@ -269,7 +269,7 @@ resources such as worker pools.
 ```python
 # app.py
 if "api" not in st.session_state:
-    st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+    st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 api: ApplicationAPI = st.session_state.api
 ```
 
@@ -734,7 +734,7 @@ separate instance.
 
 ```python
 if "api" not in st.session_state:
-    st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+    st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 api: ApplicationAPI = st.session_state.api
 ```
 

--- a/docs/engineering-reference/architecture/data-flow.md
+++ b/docs/engineering-reference/architecture/data-flow.md
@@ -220,7 +220,7 @@ LOAD:
 
 **Dependency injection chain** (preserves layer boundary -- core never imports web classes):
 ```
-app.py: ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+app.py: ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
   -> RepositoryStateManager(plot_deserializer)
     -> SessionRepository._plot_deserializer
 ```

--- a/docs/engineering-reference/architecture/system-overview.md
+++ b/docs/engineering-reference/architecture/system-overview.md
@@ -126,7 +126,7 @@ Key signatures from `app.py`:
 ```python
 # app.py
 if "api" not in st.session_state:
-    st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+    st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 ```
 
 ---

--- a/docs/engineering-reference/reference/protocol-catalog.md
+++ b/docs/engineering-reference/reference/protocol-catalog.md
@@ -18,7 +18,7 @@ nav_order: 3
 |---|----------|-------|------|------|---------|-----------------|
 | 1 | `StateManager` | Core | `src/core/state/state_manager.py` | 28 | 42 | `RepositoryStateManager` |
 | 2 | `PlotProtocol` | Core | `src/core/models/plot_protocol.py` | 18 | 1 + 8 attrs | `BasePlot` |
-| 3 | `PlotDeserializer` | Core | `src/core/models/plot_protocol.py` | 41 | 1 (`__call__`) | `BasePlot.from_dict` |
+| 3 | `PlotDeserializer` | Core | `src/core/models/plot_protocol.py` | 41 | 1 (`__call__`) | `PlotFactory.from_dict` |
 | 4 | `ServicesAPI` | Core | `src/core/services/services_api.py` | 25 | 3 properties | `DefaultServicesAPI` |
 | 5 | `DataServicesAPI` | Core | `src/core/services/data_services/data_services_api.py` | 31 | 25 | `DefaultDataServicesAPI` |
 | 6 | `ManagersAPI` | Core | `src/core/services/managers/managers_api.py` | 15 | 8 | `DefaultManagersAPI` |
@@ -130,7 +130,7 @@ nav_order: 3
 - **File**: `src/core/models/plot_protocol.py` line 41
 - **Kind**: `Callable` type alias (not a `Protocol` class)
 - **Purpose**: Callback type for dictionary-to-PlotProtocol deserialization, injected at startup.
-- **Implementation**: `BasePlot.from_dict` injected via `ApplicationAPI.__init__`
+- **Implementation**: `PlotFactory.from_dict` injected via `ApplicationAPI.__init__`
 
 ```python
 PlotDeserializer = Callable[[dict[str, Any]], PlotProtocol | None]
@@ -416,7 +416,7 @@ def __call__(self, saved_config: PlotConfig, config: PlotConfig) -> None: ...
 | Protocol | Decouples |
 |----------|-----------|
 | `PlotProtocol` | Core from Web (`BasePlot`) |
-| `PlotDeserializer` | Core from Web (`BasePlot.from_dict`) |
+| `PlotDeserializer` | Core from Web (`PlotFactory.from_dict`) |
 | `StateManager` | `ApplicationAPI` from `RepositoryStateManager` |
 | `SimulationParser` | Core from Parsing (`Gem5Parser`) |
 

--- a/docs/engineering-reference/reference/services-catalog.md
+++ b/docs/engineering-reference/reference/services-catalog.md
@@ -501,7 +501,7 @@ SENTINEL_FLOAT = -1.0
 ## Instantiation Flow
 
 ```
-app.py -> st.session_state.api -> ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+app.py -> st.session_state.api -> ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
   +-- RepositoryStateManager(plot_deserializer)
   +-- DefaultServicesAPI(state_manager)
   |     +-- DefaultManagersAPI()                         [stateless]

--- a/docs/engineering-reference/troubleshooting/performance.md
+++ b/docs/engineering-reference/troubleshooting/performance.md
@@ -176,7 +176,7 @@ finally:
 ```python
 # app.py
 if "api" not in st.session_state:
-    st.session_state.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict)
+    st.session_state.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict)
 api: ApplicationAPI = st.session_state.api
 ```
 

--- a/ring5/_export.py
+++ b/ring5/_export.py
@@ -9,12 +9,13 @@ dependency failures into typed ring5 errors.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, get_args
+from typing import get_args
 
 import plotly.graph_objects as go
 from kaleido.errors import ChromeNotFoundError
 from matplotlib.figure import Figure as MplFigure
 
+from src.core.models.visualization.figure_config import FigureConfig
 from src.web.rendering.figure_export import (
     MatplotlibFormat,
     PlotlyFormat,
@@ -23,9 +24,6 @@ from src.web.rendering.figure_export import (
 )
 
 from ring5.errors import DependencyMissingError, ExportError
-
-if TYPE_CHECKING:
-    from src.core.models.visualization.figure_config import FigureConfig
 
 # Derived from the canonical Literal types — one source of truth.
 _PLOTLY_FORMATS: tuple[str, ...] = get_args(PlotlyFormat)
@@ -46,7 +44,7 @@ def export_bytes(
     height: int = 400,
     scale: int = 2,
     dpi: int = 300,
-    spec: "FigureConfig | None" = None,
+    spec: FigureConfig | None = None,
 ) -> bytes:
     """Export a rendered figure to image/document bytes.
 
@@ -139,7 +137,7 @@ def export_file(
     height: int = 400,
     scale: int = 2,
     dpi: int = 300,
-    spec: "FigureConfig | None" = None,
+    spec: FigureConfig | None = None,
 ) -> str:
     """Export a rendered figure to a file; format defaults from the extension.
 

--- a/ring5/_session.py
+++ b/ring5/_session.py
@@ -12,9 +12,12 @@ import pandas as pd
 
 from src.core.application_api import ApplicationAPI
 from src.core.models import RestoreReport, StatConfig
+from src.core.models.data_models import ParseVariableConfig
 from src.core.models.shaper_models import ShaperStepConfig
 from src.core.models.visualization.engine import EngineMode
+from src.parsing.parser_protocol import SimulationParser
 from src.web.pages.ui.plotting.base_plot import BasePlot
+from src.web.pages.ui.plotting.plot_factory import PlotFactory
 
 from ring5 import _export, _parse, _render
 from ring5.errors import (
@@ -40,9 +43,6 @@ PlotType = Literal[
 ]
 
 if TYPE_CHECKING:
-    from src.core.models.data_models import ParseVariableConfig
-    from src.parsing.parser_protocol import SimulationParser
-
     from ring5.data import Table
 
 
@@ -115,9 +115,9 @@ class Session:
     (history, previews, CSV pool, saved configs, …).
     """
 
-    def __init__(self, *, parser: "SimulationParser | None" = None) -> None:
+    def __init__(self, *, parser: SimulationParser | None = None) -> None:
         # Headless portfolio restores need the web composition root's plot deserializer.
-        self.api = ApplicationAPI(plot_deserializer=BasePlot.from_dict, parser=parser)
+        self.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict, parser=parser)
         # Temporary parse output is removed when the session closes.
         self._owned_tmpdirs: list[str] = []
 
@@ -185,7 +185,7 @@ class Session:
             batch = self.api.submit_parse_async(
                 stats_path,
                 pattern,
-                cast("list[ParseVariableConfig | StatConfig]", list(configs)),
+                cast(list[ParseVariableConfig | StatConfig], list(configs)),
                 out_dir,
                 strategy_type=strategy,
                 scanned_vars=scanned,
@@ -199,7 +199,7 @@ class Session:
         sm.set_stats_pattern(pattern)
         sm.set_parse_variables(
             cast(
-                "list[ParseVariableConfig]",
+                list[ParseVariableConfig],
                 [
                     dict(c) if isinstance(c, dict) else {"name": c.name, "type": c.type}
                     for c in configs
@@ -384,7 +384,7 @@ class Session:
         plot_type: str,
         *,
         data: "pd.DataFrame | Table",
-        config: "FigureSpec | Mapping[str, Any]",
+        config: FigureSpec | Mapping[str, Any],
         name: str | None = None,
     ) -> BasePlot:
         """Create and register a configured plot.
@@ -423,7 +423,7 @@ class Session:
         plot_type: str,
         *,
         data: "pd.DataFrame | Table",
-        config: "FigureSpec | Mapping[str, Any]",
+        config: FigureSpec | Mapping[str, Any],
         engine: EngineMode = "plotly",
         name: str | None = None,
     ) -> _render.Figure:

--- a/ring5/decorations.py
+++ b/ring5/decorations.py
@@ -17,6 +17,7 @@ as ``ax._ring5_twin``; helpers that need it find it themselves.
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 Figure = Any  # a matplotlib Figure at runtime; kept loose so importing ring5 is cheap
@@ -291,7 +292,7 @@ class FigureDecorations:
         over = sorted(
             (coord_map[k], v)
             for k, v in values.items()
-            if k in coord_map and v == v and v > cap + 1e-9
+            if k in coord_map and not math.isnan(v) and v > cap + 1e-9
         )
         xtrans = ax.get_xaxis_transform()  # x in data coords, y in axes fraction
         placed: list[tuple[float, int]] = []

--- a/src/core/models/parsing_models.py
+++ b/src/core/models/parsing_models.py
@@ -50,7 +50,7 @@ class ScannedVariable:
 
     name: str
     type: str  # Simulator-specific type string (e.g. "scalar", "vector")
-    entries: list[str] = field(default_factory=lambda: list[str]())
+    entries: list[str] = field(default_factory=list)
     pattern_indices: list[str] | None = None
 
     def to_dict(self) -> ScannedVariableDict:
@@ -95,7 +95,7 @@ class ScanFileResult:
     """
 
     file_path: str
-    variables: list[ScannedVariable] = field(default_factory=lambda: list[ScannedVariable]())
+    variables: list[ScannedVariable] = field(default_factory=list)
     error: str | None = None
 
     @property
@@ -113,8 +113,8 @@ class ScanResult:
     them instead of silently showing "no variables".
     """
 
-    variables: list[ScannedVariable] = field(default_factory=lambda: list[ScannedVariable]())
-    failures: list[ScanFileResult] = field(default_factory=lambda: list[ScanFileResult]())
+    variables: list[ScannedVariable] = field(default_factory=list)
+    failures: list[ScanFileResult] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -140,7 +140,7 @@ class StatConfig:
     name: str
     type: str
     repeat: int = 1
-    params: dict[str, StatParamValue] = field(default_factory=lambda: dict[str, StatParamValue]())
+    params: dict[str, StatParamValue] = field(default_factory=dict)
     statistics_only: bool = False
     is_regex: bool = False
     keep_indices: bool = False

--- a/src/core/models/plot_protocol.py
+++ b/src/core/models/plot_protocol.py
@@ -33,7 +33,7 @@ class PlotProtocol(Protocol):
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the plot to a dictionary."""
-        ...
+        raise NotImplementedError
 
 
 # Type alias: a callable that deserializes a dict into a PlotProtocol.

--- a/src/core/models/visualization/palettes.py
+++ b/src/core/models/visualization/palettes.py
@@ -300,4 +300,4 @@ PALETTE_REGISTRY: dict[str, list[str]] = {
 }
 
 # Ordered list: colorblind-safe first, then Plotly alphabetical
-_PALETTE_ORDER: list[str] = list(_COLORBLIND_PALETTES.keys()) + sorted(_PLOTLY_PALETTES.keys())
+PALETTE_ORDER: list[str] = list(_COLORBLIND_PALETTES.keys()) + sorted(_PLOTLY_PALETTES.keys())

--- a/src/core/services/data_services/data_services_api.py
+++ b/src/core/services/data_services/data_services_api.py
@@ -39,19 +39,19 @@ class DataServicesAPI(Protocol):
 
     def load_csv_pool(self) -> list[CsvPoolEntry]:
         """List available CSV files in the pool with metadata."""
-        ...
+        raise NotImplementedError
 
     def add_to_csv_pool(self, file_path: str) -> str:
         """Add a CSV file to the pool. Returns pool path."""
-        ...
+        raise NotImplementedError
 
     def delete_from_csv_pool(self, file_path: str) -> bool:
         """Delete a CSV file from the pool."""
-        ...
+        raise NotImplementedError
 
     def load_csv_file(self, file_path: str) -> pd.DataFrame:
         """Load a CSV file returning a DataFrame."""
-        ...
+        raise NotImplementedError
 
     # -- Configuration Persistence --
 
@@ -63,35 +63,35 @@ class DataServicesAPI(Protocol):
         csv_path: str | None = None,
     ) -> str:
         """Save a configuration to disk. Returns saved file path."""
-        ...
+        raise NotImplementedError
 
     def load_configuration(self, config_path: str) -> SavedConfigData:
         """Load a configuration from file."""
-        ...
+        raise NotImplementedError
 
     def load_saved_configs(self) -> list[SavedConfigEntry]:
         """List all saved configurations."""
-        ...
+        raise NotImplementedError
 
     def delete_configuration(self, config_path: str) -> bool:
         """Delete a configuration file."""
-        ...
+        raise NotImplementedError
 
     # -- Cache Management --
 
     def get_cache_stats(self) -> CacheStatsInfo:
         """Return CSV pool cache statistics."""
-        ...
+        raise NotImplementedError
 
     def clear_caches(self) -> None:
         """Clear all CSV pool caches."""
-        ...
+        raise NotImplementedError
 
     # -- Variable Management --
 
     def generate_variable_id(self) -> str:
         """Generate a unique variable identifier."""
-        ...
+        raise NotImplementedError
 
     def add_variable(
         self,
@@ -99,7 +99,7 @@ class DataServicesAPI(Protocol):
         var_config: ParseVariableConfig,
     ) -> list[ParseVariableConfig]:
         """Add a new variable to the list."""
-        ...
+        raise NotImplementedError
 
     def update_variable(
         self,
@@ -108,7 +108,7 @@ class DataServicesAPI(Protocol):
         var_config: ParseVariableConfig,
     ) -> list[ParseVariableConfig]:
         """Update an existing variable at the specified index."""
-        ...
+        raise NotImplementedError
 
     def delete_variable(
         self,
@@ -116,13 +116,13 @@ class DataServicesAPI(Protocol):
         index: int,
     ) -> list[ParseVariableConfig]:
         """Delete a variable at the specified index."""
-        ...
+        raise NotImplementedError
 
     def ensure_variable_ids(
         self, variables: list[ParseVariableConfig]
     ) -> list[ParseVariableConfig]:
         """Ensure all variables have unique IDs."""
-        ...
+        raise NotImplementedError
 
     def filter_internal_stats(
         self,
@@ -130,7 +130,7 @@ class DataServicesAPI(Protocol):
         internal_stats: frozenset[str] | None = None,
     ) -> list[str]:
         """Filter out internal simulator statistics from entry list."""
-        ...
+        raise NotImplementedError
 
     def find_variable_by_name(
         self,
@@ -139,7 +139,7 @@ class DataServicesAPI(Protocol):
         exact: bool = True,
     ) -> ParseVariableConfig | None:
         """Find a variable by name (exact or regex match)."""
-        ...
+        raise NotImplementedError
 
     def aggregate_discovered_entries(
         self,
@@ -147,7 +147,7 @@ class DataServicesAPI(Protocol):
         var_name: str,
     ) -> list[str]:
         """Aggregate entries for a variable across scanned files."""
-        ...
+        raise NotImplementedError
 
     def aggregate_distribution_range(
         self,
@@ -155,15 +155,15 @@ class DataServicesAPI(Protocol):
         var_name: str,
     ) -> tuple[float | None, float | None]:
         """Aggregate min/max range for a distribution variable."""
-        ...
+        raise NotImplementedError
 
     def parse_comma_separated_entries(self, entries_str: str) -> list[str]:
         """Parse comma-separated entry string into list."""
-        ...
+        raise NotImplementedError
 
     def format_entries_as_string(self, entries: list[str]) -> str:
         """Format list of entries as comma-separated string."""
-        ...
+        raise NotImplementedError
 
     def find_entries_for_variable(
         self,
@@ -171,7 +171,7 @@ class DataServicesAPI(Protocol):
         var_name: str,
     ) -> list[str]:
         """Find all entries for a variable by searching available/scanned variables."""
-        ...
+        raise NotImplementedError
 
     def update_scanned_entries(
         self,
@@ -180,7 +180,7 @@ class DataServicesAPI(Protocol):
         new_entries: list[str],
     ) -> list[ScannedVariableDict]:
         """Update or add entries for a variable in the scanned variables list."""
-        ...
+        raise NotImplementedError
 
     def has_variable_with_name(
         self,
@@ -188,20 +188,20 @@ class DataServicesAPI(Protocol):
         name: str,
     ) -> bool:
         """Check if a variable with the given name already exists."""
-        ...
+        raise NotImplementedError
 
     def build_statistics_list(
         self,
         selected: dict[str, bool],
     ) -> list[str]:
         """Build a list of selected statistics from a boolean mapping."""
-        ...
+        raise NotImplementedError
 
     # -- Portfolio Management --
 
     def list_portfolios(self) -> list[str]:
         """List all available saved portfolios."""
-        ...
+        raise NotImplementedError
 
     def save_portfolio(
         self,
@@ -218,12 +218,12 @@ class DataServicesAPI(Protocol):
         overwrite: bool = True,
     ) -> None:
         """Serialize and save the current workspace state."""
-        ...
+        raise NotImplementedError
 
     def load_portfolio(self, name: str) -> PortfolioData:
         """Load a portfolio by name."""
-        ...
+        raise NotImplementedError
 
     def delete_portfolio(self, name: str) -> None:
         """Delete a portfolio."""
-        ...
+        raise NotImplementedError

--- a/src/core/services/managers/managers_api.py
+++ b/src/core/services/managers/managers_api.py
@@ -23,7 +23,7 @@ class ManagersAPI(Protocol):
 
     def list_operators(self) -> list[str]:
         """Return supported binary arithmetic operators."""
-        ...
+        raise NotImplementedError
 
     def apply_operation(
         self,
@@ -34,7 +34,7 @@ class ManagersAPI(Protocol):
         dest: str,
     ) -> pd.DataFrame:
         """Apply arithmetic operation between two columns."""
-        ...
+        raise NotImplementedError
 
     # -- Mixer (Multi-column merge) --
 
@@ -47,7 +47,7 @@ class ManagersAPI(Protocol):
         separator: str = "_",
     ) -> pd.DataFrame:
         """Merge multiple columns into one with SD propagation."""
-        ...
+        raise NotImplementedError
 
     def validate_merge_inputs(
         self,
@@ -57,7 +57,7 @@ class ManagersAPI(Protocol):
         new_column_name: str,
     ) -> list[str]:
         """Validate inputs for merge/mixer operations."""
-        ...
+        raise NotImplementedError
 
     # -- Outlier Removal --
 
@@ -68,7 +68,7 @@ class ManagersAPI(Protocol):
         group_by_cols: list[str],
     ) -> pd.DataFrame:
         """Remove statistical outliers based on Q3 threshold."""
-        ...
+        raise NotImplementedError
 
     def validate_outlier_inputs(
         self,
@@ -77,7 +77,7 @@ class ManagersAPI(Protocol):
         group_by_cols: list[str],
     ) -> list[str]:
         """Validate inputs for outlier removal."""
-        ...
+        raise NotImplementedError
 
     # -- Seeds Reduction --
 
@@ -88,7 +88,7 @@ class ManagersAPI(Protocol):
         statistic_cols: list[str],
     ) -> pd.DataFrame:
         """Aggregate data across random seeds (mean + stdev)."""
-        ...
+        raise NotImplementedError
 
     def validate_seeds_reducer_inputs(
         self,
@@ -97,4 +97,4 @@ class ManagersAPI(Protocol):
         statistic_cols: list[str],
     ) -> list[str]:
         """Validate inputs for seeds reduction."""
-        ...
+        raise NotImplementedError

--- a/src/core/services/services_api.py
+++ b/src/core/services/services_api.py
@@ -26,14 +26,14 @@ class ServicesAPI(Protocol):
     @property
     def managers(self) -> ManagersAPI:
         """Access stateless data transformation operations."""
-        ...
+        raise NotImplementedError
 
     @property
     def data_services(self) -> DataServicesAPI:
         """Access data storage, retrieval, and domain entity management."""
-        ...
+        raise NotImplementedError
 
     @property
     def shapers(self) -> ShapersAPI:
         """Access pipeline and shaper operations."""
-        ...
+        raise NotImplementedError

--- a/src/core/services/shapers/shapers_api.py
+++ b/src/core/services/shapers/shapers_api.py
@@ -22,7 +22,7 @@ class ShapersAPI(Protocol):
         pipeline_config: list[ShaperStepConfig],
     ) -> pd.DataFrame:
         """Apply a sequence of shapers to a DataFrame."""
-        ...
+        raise NotImplementedError
 
     def create_shaper(
         self,
@@ -30,8 +30,8 @@ class ShapersAPI(Protocol):
         params: ShaperStepConfig,
     ) -> Shaper:
         """Create a shaper instance from type and parameters."""
-        ...
+        raise NotImplementedError
 
     def get_available_shaper_types(self) -> list[str]:
         """Return all registered shaper type identifiers."""
-        ...
+        raise NotImplementedError

--- a/src/core/services/visualization/palette_service.py
+++ b/src/core/services/visualization/palette_service.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from src.core.models.visualization.palettes import (
     _COLORBLIND_PALETTES,
-    _PALETTE_ORDER,
+    PALETTE_ORDER,
     PALETTE_REGISTRY,
 )
 
@@ -65,7 +65,7 @@ def get_palette_names() -> list[str]:
     Returns:
         Ordered list of palette name strings.
     """
-    return list(_PALETTE_ORDER)
+    return list(PALETTE_ORDER)
 
 
 def is_colorblind_safe(name: str) -> bool:

--- a/src/core/state/repositories/history_repository.py
+++ b/src/core/state/repositories/history_repository.py
@@ -1,5 +1,6 @@
 """In-memory operation history for managers and portfolios."""
 
+from contextlib import suppress
 import logging
 
 from src.core.models.history_models import OperationRecord
@@ -69,17 +70,13 @@ class HistoryRepository:
 
     def remove_manager_record(self, record: OperationRecord) -> None:
         """Remove first matching record from manager history."""
-        try:
+        with suppress(ValueError):
             self._manager_history.remove(record)
-        except ValueError:
-            pass
 
     def remove_portfolio_record(self, record: OperationRecord) -> None:
         """Remove first matching record from portfolio history."""
-        try:
+        with suppress(ValueError):
             self._portfolio_history.remove(record)
-        except ValueError:
-            pass
 
     # ==================== Lifecycle ======================================
 

--- a/src/core/state/state_manager.py
+++ b/src/core/state/state_manager.py
@@ -36,230 +36,230 @@ class StateManager(Protocol):
 
     def initialize(self) -> None:
         """Initialize the state manager."""
-        ...
+        raise NotImplementedError
 
     # Data
 
     def get_data(self) -> pd.DataFrame | None:
         """Get the current raw DataFrame."""
-        ...
+        raise NotImplementedError
 
     def set_data(
         self, data: pd.DataFrame | None, on_change: Callable[[], None] | None = None
     ) -> None:
         """Set the raw DataFrame with optional change callback."""
-        ...
+        raise NotImplementedError
 
     def get_processed_data(self) -> pd.DataFrame | None:
         """Get the current processed DataFrame."""
-        ...
+        raise NotImplementedError
 
     def set_processed_data(self, data: pd.DataFrame | None) -> None:
         """Set the processed DataFrame."""
-        ...
+        raise NotImplementedError
 
     def has_data(self) -> bool:
         """Check if data is loaded."""
-        ...
+        raise NotImplementedError
 
     def clear_data(self) -> None:
         """Clear all loaded data."""
-        ...
+        raise NotImplementedError
 
     # Config
     def get_config(self) -> dict[str, Any]:
         """Get the current configuration dictionary."""
-        ...
+        raise NotImplementedError
 
     def set_config(self, config: dict[str, Any]) -> None:
         """Set the configuration dictionary."""
-        ...
+        raise NotImplementedError
 
     def update_config(self, key: str, value: object) -> None:
         """Update a single configuration key."""
-        ...
+        raise NotImplementedError
 
     def get_temp_dir(self) -> str | None:
         """Get the temporary directory path."""
-        ...
+        raise NotImplementedError
 
     def set_temp_dir(self, path: str) -> None:
         """Set the temporary directory path."""
-        ...
+        raise NotImplementedError
 
     def get_csv_path(self) -> str | None:
         """Get the current CSV file path."""
-        ...
+        raise NotImplementedError
 
     def set_csv_path(self, path: str) -> None:
         """Set the current CSV file path."""
-        ...
+        raise NotImplementedError
 
     def get_csv_pool(self) -> list[CsvPoolEntry]:
         """Get the CSV file pool."""
-        ...
+        raise NotImplementedError
 
     def set_csv_pool(self, pool: list[CsvPoolEntry]) -> None:
         """Set the CSV file pool."""
-        ...
+        raise NotImplementedError
 
     def get_saved_configs(self) -> list[SavedConfigEntry]:
         """Get list of saved configurations."""
-        ...
+        raise NotImplementedError
 
     def set_saved_configs(self, configs: list[SavedConfigEntry]) -> None:
         """Set the saved configurations list."""
-        ...
+        raise NotImplementedError
 
     # Parser
     def is_using_parser(self) -> bool:
         """Check if parser mode is active."""
-        ...
+        raise NotImplementedError
 
     def set_use_parser(self, use: bool) -> None:
         """Enable or disable parser mode."""
-        ...
+        raise NotImplementedError
 
     def get_parse_variables(self) -> list[ParseVariableConfig]:
         """Get the list of parse variable configurations."""
-        ...
+        raise NotImplementedError
 
     def set_parse_variables(self, variables: list[ParseVariableConfig]) -> None:
         """Set the parse variable configurations."""
-        ...
+        raise NotImplementedError
 
     def get_stats_path(self) -> str:
         """Get the stats file search path."""
-        ...
+        raise NotImplementedError
 
     def set_stats_path(self, path: str) -> None:
         """Set the stats file search path."""
-        ...
+        raise NotImplementedError
 
     def get_stats_pattern(self) -> str:
         """Get the stats filename pattern."""
-        ...
+        raise NotImplementedError
 
     def set_stats_pattern(self, pattern: str) -> None:
         """Set the stats filename pattern."""
-        ...
+        raise NotImplementedError
 
     def get_scanned_variables(self) -> list[ScannedVariableDict]:
         """Get the list of scanned variables."""
-        ...
+        raise NotImplementedError
 
     def set_scanned_variables(self, variables: list[ScannedVariableDict]) -> None:
         """Set the scanned variables list."""
-        ...
+        raise NotImplementedError
 
     def get_parser_strategy(self) -> str:
         """Get the current parser strategy type."""
-        ...
+        raise NotImplementedError
 
     def set_parser_strategy(self, strategy: str) -> None:
         """Set the parser strategy type."""
-        ...
+        raise NotImplementedError
 
     def get_simulator(self) -> str:
         """Get the currently selected simulator backend."""
-        ...
+        raise NotImplementedError
 
     def set_simulator(self, simulator: str) -> None:
         """Set the simulator backend to use for parsing."""
-        ...
+        raise NotImplementedError
 
     # Plots
     def get_plots(self) -> list[PlotProtocol]:
         """Get the list of plot objects."""
-        ...
+        raise NotImplementedError
 
     def set_plots(self, plots: list[PlotProtocol]) -> None:
         """Set the list of plot objects."""
-        ...
+        raise NotImplementedError
 
     def add_plot(self, plot_obj: PlotProtocol) -> None:
         """Add a plot object to the list."""
-        ...
+        raise NotImplementedError
 
     def get_plot_counter(self) -> int:
         """Get the current plot ID counter."""
-        ...
+        raise NotImplementedError
 
     def set_plot_counter(self, counter: int) -> None:
         """Set the plot ID counter."""
-        ...
+        raise NotImplementedError
 
     def start_next_plot_id(self) -> int:
         """Increment and return the next plot ID."""
-        ...
+        raise NotImplementedError
 
     def get_current_plot_id(self) -> int | None:
         """Get the currently selected plot ID."""
-        ...
+        raise NotImplementedError
 
     def set_current_plot_id(self, plot_id: int | None) -> None:
         """Set the currently selected plot ID."""
-        ...
+        raise NotImplementedError
 
     # Visualization config
     def get_visualization_config(self, plot_id: int) -> "FigureConfig | None":
         """Get the resolved visualization config for a plot, if any."""
-        ...
+        raise NotImplementedError
 
     def set_visualization_config(self, plot_id: int, config: "FigureConfig") -> None:
         """Store the visualization config for a plot."""
-        ...
+        raise NotImplementedError
 
     def remove_visualization_config(self, plot_id: int) -> None:
         """Remove the visualization config for a plot."""
-        ...
+        raise NotImplementedError
 
     # Previews
     def set_preview(self, operation_name: str, data: pd.DataFrame) -> None:
         """Store a preview DataFrame for an operation."""
-        ...
+        raise NotImplementedError
 
     def get_preview(self, operation_name: str) -> pd.DataFrame | None:
         """Get a preview DataFrame for an operation."""
-        ...
+        raise NotImplementedError
 
     def has_preview(self, operation_name: str) -> bool:
         """Check if a preview exists for an operation."""
-        ...
+        raise NotImplementedError
 
     def clear_preview(self, operation_name: str) -> None:
         """Clear a preview for an operation."""
-        ...
+        raise NotImplementedError
 
     # History
     def add_manager_history_record(self, record: OperationRecord) -> None:
         """Add an operation record to the manager history (rolling 10)."""
-        ...
+        raise NotImplementedError
 
     def get_manager_history(self) -> list[OperationRecord]:
         """Get the manager operation history."""
-        ...
+        raise NotImplementedError
 
     def add_portfolio_history_record(self, record: OperationRecord) -> None:
         """Add an operation record to the portfolio history (unbounded)."""
-        ...
+        raise NotImplementedError
 
     def get_portfolio_history(self) -> list[OperationRecord]:
         """Get the portfolio operation history."""
-        ...
+        raise NotImplementedError
 
     def remove_manager_history_record(self, record: OperationRecord) -> None:
         """Remove a specific record from manager history."""
-        ...
+        raise NotImplementedError
 
     def remove_portfolio_history_record(self, record: OperationRecord) -> None:
         """Remove a specific record from portfolio history."""
-        ...
+        raise NotImplementedError
 
     # Session
     def clear_all(self) -> None:
         """Clear all state."""
-        ...
+        raise NotImplementedError
 
     def restore_session(self, portfolio_data: PortfolioData) -> RestoreReport:
         """Restore state from a portfolio snapshot.
@@ -268,4 +268,4 @@ class StateManager(Protocol):
             A :class:`RestoreReport` recording what was restored and what
             was skipped (and why) — restore is best-effort per item.
         """
-        ...
+        raise NotImplementedError

--- a/src/parsing/gem5/impl/strategies/file_parser_strategy.py
+++ b/src/parsing/gem5/impl/strategies/file_parser_strategy.py
@@ -66,7 +66,7 @@ class FileParserStrategy(Protocol):
             >>> len(work_items)  # Number of files found
             15
         """
-        ...
+        raise NotImplementedError
 
     def post_process(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
@@ -88,4 +88,4 @@ class FileParserStrategy(Protocol):
             >>> enriched[0].keys()
             dict_keys(['ipc', 'sim_path', 'config_data', ...])
         """
-        ...
+        raise NotImplementedError

--- a/src/parsing/gem5/impl/strategies/perl_worker_pool.py
+++ b/src/parsing/gem5/impl/strategies/perl_worker_pool.py
@@ -11,6 +11,7 @@ Features:
 """
 
 import atexit
+from contextlib import suppress
 import logging
 import os
 import queue
@@ -404,10 +405,8 @@ class PerlWorker:
                     self.process.stderr,
                 ):
                     if pipe:
-                        try:
+                        with suppress(OSError):
                             pipe.close()
-                        except OSError:
-                            pass
                 self.process = None
                 self.is_healthy = False
             # Join the reader/stderr-drainer threads (their pipes are now closed,
@@ -649,14 +648,6 @@ class PerlWorkerPool:
                 worker.shutdown()
 
         logger.info("Worker pool shutdown complete")
-
-    def __del__(self) -> None:
-        """Ensure workers are cleaned up on garbage collection."""
-        try:
-            if hasattr(self, "_shutdown_event") and not self._shutdown_event.is_set():
-                self.shutdown()
-        except Exception:  # nosec B110 — __del__ must not raise
-            pass
 
 
 # Singleton instance

--- a/src/parsing/parser_protocol.py
+++ b/src/parsing/parser_protocol.py
@@ -31,7 +31,7 @@ class SimulationParser(Protocol):
         """
         Submit an asynchronous parsing job over the simulation output files.
         """
-        ...
+        raise NotImplementedError
 
     def finalize_parsing(
         self,
@@ -43,7 +43,7 @@ class SimulationParser(Protocol):
         """
         Post-process and aggregate internal parsing results into a canonical format (e.g. CSV).
         """
-        ...
+        raise NotImplementedError
 
     def submit_scan_async(
         self,
@@ -57,7 +57,7 @@ class SimulationParser(Protocol):
         Each future resolves to a ``ScanFileResult`` (variables on success,
         error on failure).
         """
-        ...
+        raise NotImplementedError
 
     def aggregate_scan_results(
         self,
@@ -67,4 +67,4 @@ class SimulationParser(Protocol):
         Aggregate per-file scan results into a ``ScanResult`` (merged,
         deduplicated variables plus any per-file failures).
         """
-        ...
+        raise NotImplementedError

--- a/src/web/components/plotting/settings/colors_settings.py
+++ b/src/web/components/plotting/settings/colors_settings.py
@@ -72,14 +72,17 @@ class ColorsSettingsComponent:
         # Palette selector
         st.markdown("#### :material/palette: Color Palette")
         palette_names = get_palette_names()
-        current_palette = saved_config.get("color_palette", "wong")
-
-        if isinstance(current_palette, list):
+        saved_palette = saved_config.get("color_palette", "wong")
+        if isinstance(saved_palette, list):
+            current_palette = next(
+                (name for name, colors in PALETTE_REGISTRY.items() if colors == saved_palette),
+                "wong",
+            )
+        elif isinstance(saved_palette, str):
+            current_palette = saved_palette
+        else:
             current_palette = "wong"
-            for name, colors in PALETTE_REGISTRY.items():
-                if colors == saved_config.get("color_palette"):
-                    current_palette = name
-                    break
+        palette_config = {**saved_config, "color_palette": current_palette}
 
         def _fmt_palette(name: str) -> str:
             label = name.replace("_", " ").title()
@@ -90,7 +93,7 @@ class ColorsSettingsComponent:
         selected_palette: str = select_option(
             "Palette",
             palette_names,
-            saved_config,
+            palette_config,
             "color_palette",
             self.plot_id,
             widget_key=f"palette_select_{self.plot_id}",

--- a/src/web/models/plot_protocols.py
+++ b/src/web/models/plot_protocols.py
@@ -57,7 +57,7 @@ class PlotHandle(Protocol):
 
     def replace_processed_data(self, data: pd.DataFrame | None) -> None:
         """Replace processed data and invalidate all derived render state."""
-        ...
+        raise NotImplementedError
 
 
 class ConfigRenderer(Protocol):
@@ -76,15 +76,15 @@ class ConfigRenderer(Protocol):
 
     def render_config_ui(self, data: pd.DataFrame, config: dict[str, Any]) -> dict[str, Any]:
         """Render plot-specific data mapping controls and return their configuration."""
-        ...
+        raise NotImplementedError
 
     def render_display_options(self, config: dict[str, Any]) -> dict[str, Any]:
         """Render plot-specific display controls and return their configuration."""
-        ...
+        raise NotImplementedError
 
     def render_theme_options(self, config: dict[str, Any]) -> dict[str, Any]:
         """Render plot-specific theme controls and return their configuration."""
-        ...
+        raise NotImplementedError
 
     def render_settings_section(
         self,
@@ -93,7 +93,7 @@ class ConfigRenderer(Protocol):
         data: pd.DataFrame | None = None,
     ) -> dict[str, Any]:
         """Render one settings section and return its updated configuration."""
-        ...
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -114,19 +114,19 @@ class RenderablePlot(PlotHandle, ConfigRenderer, Protocol):
 
     def invalidate_figure(self) -> None:
         """Discard the generated figure, traces, and their cache identity."""
-        ...
+        raise NotImplementedError
 
     def create_figure(self, data: pd.DataFrame, config: dict[str, Any]) -> go.Figure:
         """Create a Plotly figure from processed data and plot configuration."""
-        ...
+        raise NotImplementedError
 
     def apply_common_layout(self, fig: go.Figure, config: dict[str, Any]) -> go.Figure:
         """Apply shared layout settings to a Plotly figure."""
-        ...
+        raise NotImplementedError
 
     def update_from_relayout(self, relayout_data: dict[str, Any]) -> bool:
         """Apply a relayout event and report whether persistent state changed."""
-        ...
+        raise NotImplementedError
 
 
 # Service Protocols
@@ -142,21 +142,21 @@ class PlotLifecycleService(Protocol):
 
     def create_plot(self, name: str, plot_type: str, state_manager: StateManager) -> PlotHandle:
         """Create, register, and return a plot."""
-        ...
+        raise NotImplementedError
 
     def delete_plot(self, plot_id: int, state_manager: StateManager) -> None:
         """Delete a plot by identifier."""
-        ...
+        raise NotImplementedError
 
     def duplicate_plot(self, plot: PlotHandle, state_manager: StateManager) -> PlotHandle:
         """Copy, register, and return a plot."""
-        ...
+        raise NotImplementedError
 
     def change_plot_type(
         self, plot: PlotHandle, new_type: str, state_manager: StateManager
     ) -> PlotHandle:
         """Replace a plot with an equivalent instance of another type."""
-        ...
+        raise NotImplementedError
 
 
 class PlotTypeRegistry(Protocol):
@@ -169,7 +169,7 @@ class PlotTypeRegistry(Protocol):
 
     def get_available_types(self) -> list[str]:
         """Return registered plot-type identifiers."""
-        ...
+        raise NotImplementedError
 
 
 class PipelineExecutor(Protocol):
@@ -186,7 +186,7 @@ class PipelineExecutor(Protocol):
         configs: list[ShaperStepConfig],
     ) -> pd.DataFrame:
         """Apply a shaper pipeline to data."""
-        ...
+        raise NotImplementedError
 
     def configure_shaper(
         self,
@@ -197,4 +197,4 @@ class PipelineExecutor(Protocol):
         owner_id: int | None = None,
     ) -> ShaperStepConfig:
         """Render a shaper editor and return its configuration."""
-        ...
+        raise NotImplementedError

--- a/src/web/pages/portfolio.py
+++ b/src/web/pages/portfolio.py
@@ -11,7 +11,6 @@ import logging
 import streamlit as st
 
 from src.core.application_api import ApplicationAPI
-from src.core.models import PortfolioData  # noqa: F401 (re-exported)
 from src.core.services.portfolio_migrator import PortfolioVersionError
 from src.web.rendering.config_builder import build_figure_spec_dict
 

--- a/src/web/pages/ui/plotting/base_plot.py
+++ b/src/web/pages/ui/plotting/base_plot.py
@@ -2,7 +2,6 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import replace
-from io import StringIO
 from typing import Any
 
 import pandas as pd
@@ -198,33 +197,3 @@ class BasePlot(PlotConfigUIMixin, ABC):
             "legend_mappings_by_column": self.legend_mappings_by_column,
             "legend_mappings": self.legend_mappings,
         }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "BasePlot":
-        """
-        Create plot instance from dictionary.
-
-        Args:
-            data: Dictionary representation
-
-        Returns:
-            Plot instance
-        """
-        # Import here to avoid circular imports
-        from .plot_factory import PlotFactory
-
-        plot = PlotFactory.create_plot(
-            plot_type=data["plot_type"], plot_id=data["id"], name=data["name"]
-        )
-
-        plot.config = data.get("config", {})
-        plot.pipeline = data.get("pipeline", [])
-        plot.pipeline_counter = data.get("pipeline_counter", 0)
-        plot.legend_mappings_by_column = data.get("legend_mappings_by_column", {})
-        plot.legend_mappings = data.get("legend_mappings", {})
-
-        # Deserialize processed_data if it exists
-        if data.get("processed_data"):
-            plot.replace_processed_data(pd.read_csv(StringIO(data["processed_data"])))
-
-        return plot

--- a/src/web/pages/ui/plotting/plot_factory.py
+++ b/src/web/pages/ui/plotting/plot_factory.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypedDict
+from io import StringIO
+from typing import TYPE_CHECKING, Any, TypedDict
+
+import pandas as pd
 
 if TYPE_CHECKING:
     from .base_plot import BasePlot
@@ -96,6 +99,32 @@ class PlotFactory:
         # Subclasses add plot_type in their __init__ before calling super()
         # Type checker doesn't know subclass signatures, but we validate at runtime
         return plot_constructor(plot_id, name)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BasePlot:
+        """Restore a plot and its state from :meth:`BasePlot.to_dict` output.
+
+        Args:
+            data: Serialized plot mapping.
+
+        Returns:
+            Restored plot instance.
+        """
+        plot = cls.create_plot(
+            plot_type=data["plot_type"],
+            plot_id=data["id"],
+            name=data["name"],
+        )
+        plot.config = data.get("config", {})
+        plot.pipeline = data.get("pipeline", [])
+        plot.pipeline_counter = data.get("pipeline_counter", 0)
+        plot.legend_mappings_by_column = data.get("legend_mappings_by_column", {})
+        plot.legend_mappings = data.get("legend_mappings", {})
+
+        processed_data = data.get("processed_data")
+        if processed_data:
+            plot.replace_processed_data(pd.read_csv(StringIO(processed_data)))
+        return plot
 
     @classmethod
     def get_available_plot_types(cls) -> list[str]:

--- a/src/web/pages/ui/plotting/types/_trace_helpers.py
+++ b/src/web/pages/ui/plotting/types/_trace_helpers.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from src.core.models.visualization.trace_config import TraceConfig
 from src.web.models.plot_models import PlotConfig
+from src.web.pages.ui.plotting.utils.ordering import order_with_overrides
 
 
 def prepare_categorical_data(
@@ -77,10 +78,6 @@ def build_color_grouped_traces(
     traces: list[TraceConfig] = []
 
     if color_col:
-        from src.web.pages.ui.plotting.utils.grouped_stacked_bar_helpers import (
-            order_with_overrides,
-        )
-
         data = prepare_categorical_data(data, [color_col])
 
         # Shared ordering rule: explicit legend_order first, then any remaining sorted.

--- a/src/web/pages/ui/plotting/types/grouped_bar_plot.py
+++ b/src/web/pages/ui/plotting/types/grouped_bar_plot.py
@@ -124,8 +124,6 @@ class GroupedBarPlot(BasePlot):
             ordered_groups = order_with_overrides(
                 data[group_col].unique(), config.get("group_order")
             )
-        else:
-            ordered_groups = []  # Empty list instead of [None]
 
         # 2. Calculate Manual X Coordinates
         coord_result = GroupedBarUtils.calculate_grouped_coordinates(

--- a/src/web/pages/ui/plotting/utils/__init__.py
+++ b/src/web/pages/ui/plotting/utils/__init__.py
@@ -9,8 +9,8 @@ from .grouped_stacked_bar_helpers import (
     build_category_annotations,
     build_right_axis_traces,
     get_ordered_categories_and_groups,
-    order_with_overrides,
 )
+from .ordering import order_with_overrides
 
 __all__ = [
     "GroupedBarUtils",

--- a/src/web/pages/ui/plotting/utils/grouped_stacked_bar_helpers.py
+++ b/src/web/pages/ui/plotting/utils/grouped_stacked_bar_helpers.py
@@ -5,7 +5,6 @@ All functions are stateless — no UI or Streamlit imports.
 """
 
 import math
-from collections.abc import Iterable
 from typing import Any
 
 import pandas as pd
@@ -19,23 +18,7 @@ from src.core.models.visualization.trace_config import (
     TraceConfig,
 )
 from src.web.pages.ui.plotting.utils.grouped_bar_utils import GroupedBarUtils
-
-
-def order_with_overrides(present: Iterable[Any], explicit_order: list[Any] | None) -> list[str]:
-    """Order category-like values: explicit order first, then the rest sorted.
-
-    The single home for the "honour the user's explicit order (stringified),
-    then append any remaining present values in sorted order" rule shared by
-    x-axis categories (``xaxis_order``) and group/legend order. Membership is
-    checked as ``str(v) in present`` to match how callers stringify their
-    override values while leaving the present values in their native form.
-    """
-    present_list = list(present)
-    if not explicit_order:
-        return sorted(present_list)
-    ordered: list[str] = [str(v) for v in explicit_order if str(v) in present_list]
-    ordered.extend(v for v in sorted(present_list) if v not in ordered)
-    return ordered
+from src.web.pages.ui.plotting.utils.ordering import order_with_overrides
 
 
 def get_ordered_categories_and_groups(

--- a/src/web/pages/ui/plotting/utils/ordering.py
+++ b/src/web/pages/ui/plotting/utils/ordering.py
@@ -1,0 +1,22 @@
+"""Ordering helpers shared by plot trace builders."""
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def order_with_overrides(present: Iterable[Any], explicit_order: list[Any] | None) -> list[str]:
+    """Place explicit values first, then append remaining present values sorted.
+
+    Args:
+        present: Category-like values available in the current data.
+        explicit_order: Preferred leading order, or ``None`` for lexical order.
+
+    Returns:
+        Present values ordered without introducing absent categories.
+    """
+    present_list = list(present)
+    if not explicit_order:
+        return sorted(present_list)
+    ordered = [str(value) for value in explicit_order if str(value) in present_list]
+    ordered.extend(value for value in sorted(present_list) if value not in ordered)
+    return ordered

--- a/src/web/rendering/matplotlib_trace_renderer.py
+++ b/src/web/rendering/matplotlib_trace_renderer.py
@@ -176,9 +176,6 @@ class MatplotlibTraceRenderer:
         bar_border_width: float = 0.0,
     ) -> None:
         """Draw a single bar trace from its ``BarTraceConfig``."""
-        color = override_color or spec.color or None
-        is_categorical = bool(spec.x) and isinstance(spec.x[0], str)
-
         # 2) Compute standard x-positions and effective bar width
         if spec.x_positions:
             # Pre-filled numeric axis (e.g., histogram overlay)

--- a/tests/integration/test_portfolio_fix.py
+++ b/tests/integration/test_portfolio_fix.py
@@ -5,9 +5,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.core.application_api import ApplicationAPI
-
-# This import is the critical check - if this fails, the test fails immediately
-from src.web.pages.portfolio import PortfolioData, show_portfolio_page
+from src.core.models import PortfolioData
+from src.web.pages.portfolio import show_portfolio_page
 
 
 class TestPortfolioFix:

--- a/tests/integration/test_portfolio_service_integration.py
+++ b/tests/integration/test_portfolio_service_integration.py
@@ -157,15 +157,13 @@ def test_restore_returns_report_with_skipped_plots_when_no_deserializer(
 def test_restore_report_complete_with_deserializer(
     portfolio_service: Any, portfolios_dir: Any
 ) -> None:
-    from src.web.pages.ui.plotting.base_plot import BasePlot
-
     df = pd.DataFrame({"A": [1, 2]})
     plot = PlotFactory.create_plot("bar", 2, "OK Plot")
     plot.processed_data = df
     plot.config = {"x": "A", "y": "A"}
     portfolio_service.save_portfolio("report_ok", df, [plot], {}, 1)
 
-    fresh_manager = RepositoryStateManager(plot_deserializer=BasePlot.from_dict)
+    fresh_manager = RepositoryStateManager(plot_deserializer=PlotFactory.from_dict)
     loaded = portfolio_service.load_portfolio("report_ok")
     report = fresh_manager.restore_session(loaded)
 

--- a/tests/unit/test_base_plot.py
+++ b/tests/unit/test_base_plot.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.core.models.visualization.trace_build_result import TraceBuildResult
 from src.web.pages.ui.plotting.base_plot import BasePlot
+from src.web.pages.ui.plotting.plot_factory import PlotFactory
 from tests.conftest import columns_side_effect
 
 
@@ -74,12 +75,11 @@ def test_serialization(concrete_plot: Any) -> None:
     assert data["config"] == {"x": "col1"}
     assert "processed_data" in data
 
-    # Test loading
-    # Need to patch PlotFactory to avoiding circular imports or logic
+    # Restore through the factory while controlling the concrete plot type.
     with patch("src.web.pages.ui.plotting.plot_factory.PlotFactory.create_plot") as mock_factory:
         mock_factory.return_value = ConcretePlot(1, "Test Plot", "test")
 
-        loaded_plot = BasePlot.from_dict(data)
+        loaded_plot = PlotFactory.from_dict(data)
 
         assert loaded_plot.plot_id == 1
         assert loaded_plot.config == {"x": "col1"}

--- a/tests/unit/test_base_plot_relayout.py
+++ b/tests/unit/test_base_plot_relayout.py
@@ -9,6 +9,7 @@ import pytest
 
 from src.core.models.visualization.trace_build_result import TraceBuildResult
 from src.web.pages.ui.plotting.base_plot import BasePlot
+from src.web.pages.ui.plotting.plot_factory import PlotFactory
 
 
 class ConcretePlot(BasePlot):
@@ -234,7 +235,7 @@ class TestToDictFromDict:
         }
         with patch("src.web.pages.ui.plotting.plot_factory.PlotFactory.create_plot") as mock:
             mock.return_value = ConcretePlot(1, "Test", "test")
-            loaded = BasePlot.from_dict(data)
+            loaded = PlotFactory.from_dict(data)
             assert loaded.processed_data is None
 
     def test_from_dict_preserves_pipeline_counter(self, plot: ConcretePlot) -> None:
@@ -251,7 +252,7 @@ class TestToDictFromDict:
         }
         with patch("src.web.pages.ui.plotting.plot_factory.PlotFactory.create_plot") as mock:
             mock.return_value = ConcretePlot(1, "Test", "test")
-            loaded = BasePlot.from_dict(data)
+            loaded = PlotFactory.from_dict(data)
             assert loaded.pipeline_counter == 5
             assert loaded.legend_mappings_by_column == {"col": {"a": "A"}}
             assert loaded.legend_mappings == {"x": "X"}

--- a/tests/unit/test_colorblind_palettes.py
+++ b/tests/unit/test_colorblind_palettes.py
@@ -77,6 +77,24 @@ class TestPaletteSelector:
             result = comp.render({}, data=None)
         assert result["color_palette"] == "viridis_8"
 
+    @patch("src.web.components.plotting.settings.colors_settings.select_option")
+    @patch("src.web.components.plotting.settings.colors_settings.st")
+    def test_legacy_palette_list_selects_matching_name(
+        self,
+        mock_st: MagicMock,
+        mock_select_option: MagicMock,
+    ) -> None:
+        """Legacy color lists initialize the selector with their registry name."""
+        mock_select_option.return_value = "viridis_8"
+        comp = self._make_component()
+        comp._render_series_section = MagicMock(return_value={})
+        comp._render_backgrounds_section = MagicMock(return_value={})
+
+        comp.render({"color_palette": list(PALETTE_REGISTRY["viridis_8"])})
+
+        palette_config = mock_select_option.call_args.args[2]
+        assert palette_config["color_palette"] == "viridis_8"
+
     @patch("src.web.components.plotting.settings.colors_settings.st")
     def test_swatch_html_is_rendered(self, mock_st: MagicMock) -> None:
         """Verify markdown is called with swatch HTML."""

--- a/tests/unit/test_dual_axis_bar_dot_plot.py
+++ b/tests/unit/test_dual_axis_bar_dot_plot.py
@@ -321,13 +321,11 @@ class TestDualAxisBarDotPlotSerialization:
 
     def test_from_dict_roundtrip(self, sample_data: pd.DataFrame) -> None:
         """Test round-trip serialization."""
-        from src.web.pages.ui.plotting.base_plot import BasePlot
-
         plot = DualAxisBarDotPlot(1, "Test Dual")
         plot.processed_data = sample_data
         plot.config = {"x": "Benchmark", "y_bar": "CycleCount", "y_dot": "IPC"}
         data_dict = plot.to_dict()
-        restored = BasePlot.from_dict(data_dict)
+        restored = PlotFactory.from_dict(data_dict)
         assert isinstance(restored, DualAxisBarDotPlot)
         assert restored.plot_type == "dual_axis_bar_dot"
         assert restored.config == plot.config

--- a/tests/unit/test_plot_classes.py
+++ b/tests/unit/test_plot_classes.py
@@ -9,7 +9,6 @@ from pandas import DataFrame
 
 from src.web.pages.ui.plotting import (
     BarPlot,
-    BasePlot,
     GroupedBarPlot,
     GroupedStackedBarPlot,
     LinePlot,
@@ -242,7 +241,7 @@ class TestPlotSerialization:
         data_dict = plot.to_dict()
 
         # Deserialize
-        restored_plot = BasePlot.from_dict(data_dict)
+        restored_plot = PlotFactory.from_dict(data_dict)
 
         assert restored_plot.plot_id == plot.plot_id
         assert restored_plot.name == plot.name


### PR DESCRIPTION
## Summary

This follow-up addresses the default-branch CodeQL inventory exposed after #50 merged. The analysis reported 154 open maintainability findings: 152 actionable Python findings and two historical workflow-permission alerts whose recorded instances predate the current explicit read-only workflow permissions.

- replace inert protocol and abstract-method bodies with explicit contracts
- move plot restoration into `PlotFactory` and remove the reverse dependency from `BasePlot`
- move trace ordering into a neutral utility to break the plotting helper cycle
- remove unused imports, assignments, lambdas, and redundant exception handling
- simplify Perl worker cleanup and use a direct NaN predicate
- fix legacy palette-list normalization so matching palettes initialize correctly
- update API and architecture documentation for the restored factory boundary

## Validation

- architecture dependency check
- comment, public-docstring, and documentation-link audits
- Black, Flake8, and MyPy (254 source files)
- 3,618 non-browser tests passed; 1 skipped
- 116 browser E2E tests passed
- 22 Plotly/Chrome export tests passed
- 4 XeLaTeX/PGF tests passed
- dependency declaration check and `pip check`
- Bandit and `pip-audit`
- wheel and sdist builds with Twine validation

## Convergence criterion

Keep this draft until hosted CI and CodeQL complete. Any remaining current-branch findings should be fixed before marking it ready. Historical alerts should only be dismissed after their recorded commit and the current workflow permissions are verified.