### PR TITLE
Eliminate residual CodeQL ellipsis findings

### DIFF
--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -67,6 +67,12 @@ def inspect_file(path: Path) -> list[str]:
                 issues.append(f"{location}: domain/data layer accesses session_state")
         if isinstance(node, ast.ExceptHandler) and node.type is None:
             issues.append(f"{location}: bare except clause")
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and node.value.value is Ellipsis
+        ):
+            issues.append(f"{location}: ellipsis statement; use an explicit contract")
         if isinstance(node, ast.Call):
             if isinstance(node.func, ast.Name) and node.func.id in {"eval", "exec"}:
                 issues.append(f"{location}: call to {node.func.id}()")

--- a/src/web/components/plotting/settings/advanced_settings.py
+++ b/src/web/components/plotting/settings/advanced_settings.py
@@ -38,7 +38,9 @@ class ReferenceLineRenderer(Protocol):
         saved_config: PlotConfig,
         data: pd.DataFrame | None,
         config: PlotConfig,
-    ) -> None: ...
+    ) -> None:
+        """Render reference-line controls into ``config``."""
+        raise NotImplementedError
 
 
 class ShapesRenderer(Protocol):
@@ -47,7 +49,9 @@ class ShapesRenderer(Protocol):
     def __call__(
         self,
         saved_config: PlotConfig,
-    ) -> list[ShapeConfig]: ...
+    ) -> list[ShapeConfig]:
+        """Render shape controls and return their configuration."""
+        raise NotImplementedError
 
 
 class EngineControlsRenderer(Protocol):
@@ -57,7 +61,9 @@ class EngineControlsRenderer(Protocol):
         self,
         saved_config: PlotConfig,
         config: PlotConfig,
-    ) -> None: ...
+    ) -> None:
+        """Render engine-specific controls into ``config``."""
+        raise NotImplementedError
 
 
 class AdvancedSettingsComponent:

--- a/src/web/components/plotting/settings/axes_settings.py
+++ b/src/web/components/plotting/settings/axes_settings.py
@@ -55,7 +55,9 @@ class SpecificOptionsRenderer(Protocol):
         self,
         saved_config: PlotConfig,
         data: pd.DataFrame | None,
-    ) -> PlotConfig: ...
+    ) -> PlotConfig:
+        """Render plot-specific options and return the updated configuration."""
+        raise NotImplementedError
 
 
 class OrderingRenderer(Protocol):
@@ -66,7 +68,9 @@ class OrderingRenderer(Protocol):
         saved_config: PlotConfig,
         data: pd.DataFrame,
         config: PlotConfig,
-    ) -> None: ...
+    ) -> None:
+        """Render ordering controls into ``config``."""
+        raise NotImplementedError
 
 
 class AxesSettingsComponent:


### PR DESCRIPTION
## Summary

The post-merge default-branch analysis for #51 reduced the Python CodeQL inventory from 152 results to five. All five residual findings were inline ellipsis statements in plotting settings protocols; the earlier standalone-line audit did not match that form.

- replace the five inline ellipses with explicit, documented `NotImplementedError` contracts
- extend the AST architecture check to reject ellipsis statements in production code
- keep the change scoped to the two affected settings modules and the regression guard

## Validation

- architecture and comment audits
- Black and Flake8
- MyPy (254 source files)
- 77 focused settings tests
- clean diff and no remaining production ellipsis statements

## Convergence criterion

Keep this draft until hosted CI and CodeQL complete. Merge only if the PR analysis reports zero results, then verify the new default-branch analysis and resolve the two historical workflow-permission alerts separately from current code.