### PR TITLE
Complete the public API workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,9 @@ jobs:
         run: |
           python -m venv python_venv
           python_venv/bin/python -m pip install "pip==26.1.2"
-          python_venv/bin/pip install -e ".[dev,ci]"
+          # The coverage gate collects the full test tree before marker filtering,
+          # so its environment must be able to import the E2E conftest module.
+          python_venv/bin/pip install -e ".[dev,ci,e2e]"
 
       - name: Prepare test fixtures
         run: make test-data mock-data

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ NON_BROWSER_TESTS := tests/unit tests/integration tests/ui tests/ui_logic tests/
 	tests/performance tests/tests_principle_compliance
 
 .PHONY: help venv install dev run playwright-install install-latex check-latex \
-	test-data mock-data test test-unit test-nonbrowser test-ci test-export test-latex \
+	test-data mock-data test test-unit test-nonbrowser test-api test-ci test-export test-latex \
 	test-e2e test-visual \
 	format format-check lint type-check arch-check comments-check docs-check dependency-check \
 	docs-build docs-audit security-audit quality-gate package-check check-outdated pre-commit-install \
@@ -29,6 +29,7 @@ help:
 	@echo "  test-unit           Run fast unit tests"
 	@echo "  test                Run non-browser tests, including serial exports"
 	@echo "  test-latex          Run tests that require a local XeLaTeX installation"
+	@echo "  test-api            Run the exact 100% line/branch public API gate"
 	@echo "  test-ci             Run tests with the coverage gate"
 	@echo "  test-e2e            Run Playwright browser tests"
 	@echo "  quality-gate        Run architecture, docs, format, lint, types, and security"
@@ -103,6 +104,10 @@ test-nonbrowser:
 test-export:
 	$(PYTEST) tests/unit/test_plotly_download.py -m "serial" -n 0 --timeout=120 --no-cov
 
+test-api: test-data mock-data
+	$(PYTEST) -m "public_api" -n 0 --cov=ring5 --cov-branch \
+		--cov-report=term-missing --cov-fail-under=100 --timeout=120
+
 test-latex:
 	$(PYTEST) tests/unit/test_matplotlib_download.py::TestMatplotlibPGF \
 		-m "requires_latex" -n 0 --timeout=120 --no-cov
@@ -111,7 +116,7 @@ test: test-data mock-data
 	$(MAKE) test-nonbrowser
 	$(MAKE) test-export
 
-test-ci: test-data mock-data
+test-ci: test-data mock-data test-api
 	$(PYTEST) $(NON_BROWSER_TESTS) -m "not serial and not requires_latex" \
 		--cov=src --cov=ring5 --cov-branch --cov-report=term-missing \
 		--cov-report=xml --cov-fail-under=$(COVERAGE_MIN) --timeout=60

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ with ring5.Session() as session:
     session.export(figure, "ipc.pdf", deterministic=True)
 ```
 
-Use `ring5.available_plot_types()` to discover registered plot identifiers. The
+Use `ring5.available_plot_types()` and `ring5.available_shaper_types()` to discover registered
+workflow identifiers. The
 [scripting workflow](https://nikiitin.github.io/RING-5/user-guide/workflows/scripting/) covers
 parsing, transformations, portfolios, and the CLI.
 
@@ -61,6 +62,7 @@ parsing, transformations, portfolios, and the CLI.
 
 ```bash
 make quality-gate
+make test-api
 make test-ci
 make test-e2e
 make package-check

--- a/docs/developer-guide/api-reference/public-python-api.md
+++ b/docs/developer-guide/api-reference/public-python-api.md
@@ -9,8 +9,8 @@ permalink: /developer-guide/api-reference/public-python-api/
 
 # Public Python API
 
-`ring5` is the supported headless surface. Public names are exported from `ring5/__init__.py` and
-covered by `tests/integration/test_ring5_public_api.py`.
+`ring5` is the supported headless surface. Public names are exported from `ring5/__init__.py`. The
+tests marked `public_api` enforce exact line and branch coverage for the package (`make test-api`).
 
 ## Workspace
 
@@ -19,18 +19,28 @@ manager operations and shaper pipelines, create and render plots, export figures
 restore portfolios. Use it as a context manager so pending session work and temporary parser output
 are released.
 
-`Session.parse_submit` returns an owned `ParseJob`; `Session.parse` waits and returns `ParseResult`.
-`Session.load` returns a DataFrame. `shape`, `reduce_seeds`, and `remove_outliers` preserve
-`ring5.Table` when given one.
+`Session.scan_submit` returns an owned `ScanJob`; `Session.scan` waits and returns `ScanResult`.
+Likewise, `parse_submit` returns `ParseJob` and `parse` returns `ParseResult`. A job can be cancelled
+without touching work from another handle. `Session.load` returns a DataFrame. `shape`,
+`reduce_seeds`, `remove_outliers`, `apply_operation`, and `mix_columns` preserve `ring5.Table` when
+given one.
 
 `scan_limit=0` means exhaustive variable discovery up to the global 10,000-file ceiling; a positive
-value is an exact sample cap. A scan with any failed files raises `ScanError` at the public boundary
-instead of returning incomplete variable metadata. Parser worker, aggregate resource, pattern
-expansion, and ten-minute batch timeout failures are wrapped as `ParseError`.
+value is an exact sample cap. A scan with any failed files raises `ScanError` at the public boundary;
+pass `strict=False` to `ScanJob.finalize` or `Session.scan` only when a documented partial result is
+acceptable. Parser worker, aggregate resource, pattern expansion, and ten-minute batch timeout
+failures are wrapped as `ParseError`.
+
+The `config_aware` parser strategy adds deterministic `sim_path` and `config_json` columns. It
+requires a readable, non-empty `config.ini` beside every selected stats file. Gem5 scalar-name
+patterns, conventional distributions, range histograms, and pipe-delimited one-line histograms are
+all supported by the public parse workflow.
 
 `create_plot` registers a plot and `render` renders it. `plot` performs both. Plot identifiers come
 from `ring5.available_plot_types()`; display names are accepted but identifiers are preferable in
-versioned scripts.
+versioned scripts. Mapping configurations are validated before registration for required fields,
+field types, and referenced columns. Every downstream engine failure is normalized to `RenderError`.
+`ring5.available_shaper_types()` provides the equivalent registry for pipelines.
 
 ## Figure configuration and export
 
@@ -56,4 +66,4 @@ submission, resource-limit, worker, timeout, and assembly failures. Public bound
 original failure as `__cause__` where wrapping adds API context.
 
 When adding a public name, export it lazily where appropriate, document parameters and exceptions,
-add integration coverage, and update the User Guide.
+add a `public_api` contract test, keep `make test-api` at 100%, and update the User Guide.

--- a/docs/user-guide/reference/shapers.md
+++ b/docs/user-guide/reference/shapers.md
@@ -57,3 +57,7 @@ Serialized configuration is validated by each shaper. Use the web configuration 
 models documented in the
 [Developer Guide]({{site.baseurl}}/developer-guide/api-reference/models-and-protocols/) rather than
 guessing keys for complex steps.
+
+Call `ring5.available_shaper_types()` for the current serialized identifiers. Direct, supported
+class imports live in `ring5.shapers`; this includes `ColumnSelector`, `ConditionSelector`,
+`ItemSelector`, and the group selector variants in addition to the calculation and pivot shapers.

--- a/docs/user-guide/workflows/scripting.md
+++ b/docs/user-guide/workflows/scripting.md
@@ -20,6 +20,8 @@ without exposing `src.*` modules as a supported interface.
 import ring5
 
 with ring5.Session() as session:
+    discovered = session.scan("results/", limit=0)
+    assert any(variable.name == "system.cpu.ipc" for variable in discovered.variables)
     parsed = session.parse(
         "results/",
         variables=["simTicks", "system.cpu.ipc"],
@@ -50,11 +52,19 @@ The context manager cancels pending session work and removes temporary parser ou
 worker pools remain reusable; long-running programs can call `ring5.shutdown()` to release them
 early.
 
+Use `scan_submit`/`parse_submit` when work should overlap with other application tasks. Their
+`ScanJob` and `ParseJob` handles own cancellation and finalization. A session never deletes its
+temporary output while an already-running parse worker can still write to it.
+
+The optional `strategy="config_aware"` parse mode adds `sim_path` and compact, key-sorted
+`config_json` columns. Each run must contain a valid `config.ini` beside its stats file.
+
 ## Discover and handle errors
 
-Use `ring5.available_plot_types()` rather than copying a registry inventory. Public failures inherit
-from `ring5.Ring5Error`, with narrower types such as `ParseError`, `PipelineError`, `RenderError`,
-and `ExportError`.
+Use `ring5.available_plot_types()` and `ring5.available_shaper_types()` rather than copying registry
+inventories. Plot mappings are checked for required keys and referenced columns before a plot is
+registered. Public failures inherit from `ring5.Ring5Error`, with narrower types such as
+`ParseError`, `PipelineError`, `RenderError`, and `ExportError`.
 
 ```python
 try:
@@ -81,6 +91,6 @@ defaults to HTML. Pass `--no-deterministic` only when byte-stable output is not 
 ## Use portable table scripts
 
 `ring5.Table` and `ring5.read_table` provide a pandas-independent handle for figure scripts.
-`Session.shape`, `reduce_seeds`, and `remove_outliers` return a `Table` when given one; plot methods
-also accept it. Use a DataFrame when the analysis needs pandas operations outside the supported
-surface.
+`Session.shape`, `reduce_seeds`, `remove_outliers`, `apply_operation`, and `mix_columns` return a
+`Table` when given one; plot methods also accept it. Use a DataFrame when the analysis needs pandas
+operations outside the supported surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ python_functions = "test_*"
 addopts = "-v --tb=short --strict-markers -n 3 --dist loadgroup"
 xfail_strict = true
 markers = [
+  "public_api: Tests that enforce the supported ring5 Python API contract",
   "requires_latex: Tests that require LaTeX installation",
   "requires_browser: Tests that require a running browser/server",
   "benchmark: marks tests as performance benchmarks (deselect with '-m \"not benchmark\"')",
@@ -110,6 +111,11 @@ markers = [
   "slow: Marks tests as slow (deselect with '-m \"not slow\"')",
   "xdist_group: Group tests to run on the same xdist worker",
   "serial: Tests that must run WITHOUT xdist parallelism (e.g. Kaleido Chromium raster export deadlocks/starves under -n 3); run them in a separate '-n 0' pass",
+]
+
+[tool.coverage.report]
+exclude_also = [
+  "if TYPE_CHECKING:",
 ]
 
 [tool.black]

--- a/ring5/__init__.py
+++ b/ring5/__init__.py
@@ -69,14 +69,16 @@ from ring5.figure_spec import (
 
 if TYPE_CHECKING:
     # Static names for mypy/IDEs; at runtime these resolve via __getattr__.
-    from src.core.models import RestoreReport
+    from src.core.models import RestoreReport, ScanResult, ScannedVariable, ShaperStepConfig
     from src.core.models.parsing_models import StatConfig
 
     from ring5._export import export_bytes, export_file
     from ring5._parse import ParseJob, ParseResult
+    from ring5._scan import ScanJob
     from ring5._portfolio import render_portfolio
     from ring5._render import render_figure
     from ring5._session import PlotType, Session, available_plot_types
+    from ring5.shapers import available_shaper_types
     from ring5.coordinates import grouped_bar_coordinates
     from ring5.data import Table, read_table
     from ring5.decorations import FigureDecorations
@@ -95,12 +97,17 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "available_plot_types": ("ring5._session", "available_plot_types"),
     "ParseJob": ("ring5._parse", "ParseJob"),
     "ParseResult": ("ring5._parse", "ParseResult"),
+    "ScanJob": ("ring5._scan", "ScanJob"),
+    "ScanResult": ("src.core.models", "ScanResult"),
+    "ScannedVariable": ("src.core.models", "ScannedVariable"),
     "render_figure": ("ring5._render", "render_figure"),
     "export_bytes": ("ring5._export", "export_bytes"),
     "export_file": ("ring5._export", "export_file"),
     "render_portfolio": ("ring5._portfolio", "render_portfolio"),
     "StatConfig": ("src.core.models.parsing_models", "StatConfig"),
     "RestoreReport": ("src.core.models", "RestoreReport"),
+    "ShaperStepConfig": ("src.core.models", "ShaperStepConfig"),
+    "available_shaper_types": ("ring5.shapers", "available_shaper_types"),
     # Self-contained figure-scripting surface (so scripts import only `ring5`):
     "grouped_bar_coordinates": ("ring5.coordinates", "grouped_bar_coordinates"),
     "FigureDecorations": ("ring5.decorations", "FigureDecorations"),
@@ -146,9 +153,14 @@ __all__ = [
     "Session",
     "PlotType",
     "available_plot_types",
+    "available_shaper_types",
     "StatConfig",
     "ParseJob",
     "ParseResult",
+    "ScanJob",
+    "ScanResult",
+    "ScannedVariable",
+    "ShaperStepConfig",
     "RestoreReport",
     "render_figure",
     "export_bytes",

--- a/ring5/_parse.py
+++ b/ring5/_parse.py
@@ -17,6 +17,7 @@ import pandas as pd
 from src.core.common.security_limits import PARSE_BATCH_TIMEOUT_SECONDS
 from src.core.models import StatConfig
 
+from ring5._scan import ScanJob
 from ring5.errors import MissingStatError, ParseError, ScanError
 
 if TYPE_CHECKING:
@@ -172,18 +173,11 @@ def build_stat_configs(
 
     try:
         futures = api.submit_scan_async(stats_path, pattern, limit=scan_limit)
-        scan = api.finalize_scan([f.result() for f in futures])
+        scan = ScanJob(api, list(futures), stats_path, pattern).finalize()
+    except ScanError:
+        raise
     except (OSError, RuntimeError, ValueError) as exc:
         raise ScanError(str(exc)) from exc
-
-    if scan.failures:
-        first = scan.failures[0]
-        raise ScanError(
-            f"Scanning was incomplete: {len(scan.failures)} of "
-            f"{scan.scanned_files or len(futures)} file(s) failed "
-            f"(first error in {first.file_path}: {first.error}). "
-            "Is perl installed and the stats path correct?"
-        )
 
     by_name = {v.name: v for v in scan.variables}
     configs: list[StatConfig | dict[str, Any]] = []

--- a/ring5/_plot_validation.py
+++ b/ring5/_plot_validation.py
@@ -1,0 +1,115 @@
+"""Validation for the mapping-based public plot configuration surface."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pandas as pd
+
+from ring5.errors import ColumnNotFoundError, DataValidationError
+
+_REQUIRED_SINGLE: dict[str, tuple[str, ...]] = {
+    "bar": ("x", "y"),
+    "dual_axis_bar_dot": ("x", "y_bar", "y_dot"),
+    "grouped_bar": ("x", "y"),
+    "grouped_stacked_bar": ("x",),
+    "heatmap": ("x",),
+    "histogram": ("histogram_variable",),
+    "line": ("x", "y"),
+    "scatter": ("x", "y"),
+    "stacked_bar": ("x",),
+}
+
+_REQUIRED_LIST: dict[str, tuple[str, ...]] = {
+    "grouped_stacked_bar": ("y_columns",),
+    "heatmap": ("metric_columns",),
+    "stacked_bar": ("y_columns",),
+}
+
+_OPTIONAL_SINGLE: dict[str, tuple[str, ...]] = {
+    "bar": ("color",),
+    "dual_axis_bar_dot": ("color",),
+    "grouped_bar": ("group",),
+    "grouped_stacked_bar": ("group",),
+    "heatmap": ("facet_col",),
+    "histogram": ("group_by",),
+    "line": ("color",),
+    "scatter": ("color",),
+}
+
+_OPTIONAL_LIST: dict[str, tuple[str, ...]] = {
+    "grouped_stacked_bar": ("y_columns_right",),
+}
+
+
+def _column(data: pd.DataFrame, config: Mapping[str, Any], field: str, *, required: bool) -> None:
+    value = config.get(field)
+    if value is None and not required:
+        return
+    if not isinstance(value, str) or not value:
+        qualifier = "required" if required else "optional"
+        raise DataValidationError(
+            f"Plot config field {field!r} is {qualifier} and must be a non-empty string."
+        )
+    if value not in data.columns:
+        raise ColumnNotFoundError(value, list(data.columns))
+
+
+def _columns(data: pd.DataFrame, config: Mapping[str, Any], field: str, *, required: bool) -> None:
+    value = config.get(field)
+    if value is None and not required:
+        return
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(column, str) or not column for column in value)
+    ):
+        qualifier = "a non-empty" if required else "an optional non-empty"
+        raise DataValidationError(
+            f"Plot config field {field!r} must be {qualifier} list of column names."
+        )
+    for column in value:
+        if column not in data.columns:
+            raise ColumnNotFoundError(column, list(data.columns))
+
+
+def validate_plot_config(plot_type: str, data: pd.DataFrame, config: Mapping[str, Any]) -> None:
+    """Validate required fields, their types, and every referenced column.
+
+    Args:
+        plot_type: Registered snake-case plot identifier.
+        data: Data available to the plot.
+        config: Flat renderer configuration mapping.
+
+    Raises:
+        ColumnNotFoundError: A referenced column is absent.
+        DataValidationError: A required field or value type is invalid.
+    """
+    for field in _REQUIRED_SINGLE[plot_type]:
+        if plot_type == "histogram" and field == "histogram_variable":
+            value = config.get(field)
+            if not isinstance(value, str) or not value:
+                raise DataValidationError(
+                    "Plot config field 'histogram_variable' is required and must be a "
+                    "non-empty string."
+                )
+            bucket_prefix = f"{value}.."
+            if not any(
+                isinstance(column, str)
+                and column.startswith(bucket_prefix)
+                and not column.endswith(".sd")
+                for column in data.columns
+            ):
+                raise DataValidationError(
+                    f"No histogram bucket columns found for variable {value!r}."
+                )
+            continue
+        _column(data, config, field, required=True)
+
+    for field in _REQUIRED_LIST.get(plot_type, ()):
+        _columns(data, config, field, required=True)
+    for field in _OPTIONAL_SINGLE.get(plot_type, ()):
+        _column(data, config, field, required=False)
+    for field in _OPTIONAL_LIST.get(plot_type, ()):
+        _columns(data, config, field, required=False)

--- a/ring5/_render.py
+++ b/ring5/_render.py
@@ -50,32 +50,41 @@ def render_figure(plot: BasePlot, *, engine: EngineMode = "plotly") -> Figure:
     if plot.processed_data is None:
         raise RenderError(f"Plot '{plot.name}' has no processed data to render.")
 
-    if engine == "plotly":
-        # UI sequence (render_controller.py): create_figure + apply_common_layout.
-        plotly_fig = plot.create_figure(plot.processed_data, plot.config)
-        plotly_fig = plot.apply_common_layout(plotly_fig, plot.config)
-        plot.last_generated_fig = plotly_fig
-        plot.last_figure_cache_key = None
-        return plotly_fig
+    try:
+        if engine == "plotly":
+            # UI sequence (render_controller.py): create_figure + apply_common_layout.
+            plotly_fig = plot.create_figure(plot.processed_data, plot.config)
+            plotly_fig = plot.apply_common_layout(plotly_fig, plot.config)
+            plot.last_generated_fig = plotly_fig
+            plot.last_figure_cache_key = None
+            return plotly_fig
 
-    # Matplotlib: build straight from the engine-agnostic traces — NO Plotly figure is
-    # constructed (the two engines are independent). create_traces + the same legend
-    # relabel create_figure would apply, then the traces-direct matplotlib builder.
-    import matplotlib.pyplot as plt
+        # Matplotlib: build straight from the engine-agnostic traces — NO Plotly figure is
+        # constructed (the two engines are independent). create_traces + the same legend
+        # relabel create_figure would apply, then the traces-direct matplotlib builder.
+        import matplotlib.pyplot as plt
 
-    from src.web.pages.ui.plotting.base_plot import _relabel_traces
-    from src.web.rendering.matplotlib_figure_builder import build_matplotlib_figure_from_traces
+        from src.web.pages.ui.plotting.base_plot import _relabel_traces
+        from src.web.rendering.matplotlib_figure_builder import (
+            build_matplotlib_figure_from_traces,
+        )
 
-    traces_result = plot.create_traces(plot.processed_data, plot.config)
-    traces_result = _relabel_traces(traces_result, plot.config.get("legend_labels"))
-    plot.last_traces = traces_result
+        traces_result = plot.create_traces(plot.processed_data, plot.config)
+        traces_result = _relabel_traces(traces_result, plot.config.get("legend_labels"))
+        plot.last_traces = traces_result
 
-    mpl_fig, spec = build_matplotlib_figure_from_traces(plot.config, plot.plot_type, traces_result)
+        mpl_fig, spec = build_matplotlib_figure_from_traces(
+            plot.config, plot.plot_type, traces_result
+        )
 
-    # Deregister from pyplot: headless callers loop over many plots
-    # (render_portfolio), and pyplot would otherwise pin every figure in
-    # its global manager. The Figure object stays fully usable (savefig).
-    plt.close(mpl_fig)
+        # Deregister from pyplot: headless callers loop over many plots
+        # (render_portfolio), and pyplot would otherwise pin every figure in
+        # its global manager. The Figure object stays fully usable (savefig).
+        plt.close(mpl_fig)
 
-    mpl_fig._ring5_spec = spec  # type: ignore[attr-defined]
-    return mpl_fig
+        mpl_fig._ring5_spec = spec  # type: ignore[attr-defined]
+        return mpl_fig
+    except (AttributeError, IndexError, KeyError, RuntimeError, TypeError, ValueError) as exc:
+        raise RenderError(
+            f"Could not render plot '{plot.name}' ({plot.plot_type}) with {engine}: {exc}"
+        ) from exc

--- a/ring5/_scan.py
+++ b/ring5/_scan.py
@@ -1,0 +1,69 @@
+"""Handle-based scanning for the public API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from src.core.common.security_limits import SCAN_BATCH_TIMEOUT_SECONDS
+from src.core.models import ScanFileResult, ScanResult
+
+from ring5.errors import ScanError
+
+if TYPE_CHECKING:
+    from concurrent.futures import Future
+
+    from src.core.application_api import ApplicationAPI
+
+
+@dataclass
+class ScanJob:
+    """A submitted scan batch whose handle owns its futures and context."""
+
+    api: "ApplicationAPI"
+    futures: list["Future[ScanFileResult]"]
+    stats_path: str
+    stats_pattern: str
+
+    def cancel(self) -> None:
+        """Cancel only work belonging to this scan job."""
+        for future in self.futures:
+            future.cancel()
+
+    def finalize(self, *, strict: bool = True) -> ScanResult:
+        """Wait for discovery and aggregate its per-file results.
+
+        Args:
+            strict: Raise :class:`ScanError` if any selected file failed.
+                With ``False``, return the partial result with ``failures``.
+        """
+        from concurrent.futures import wait
+
+        _done, pending = wait(self.futures, timeout=SCAN_BATCH_TIMEOUT_SECONDS)
+        if pending:
+            cancelled = sum(future.cancel() for future in pending)
+            raise ScanError(
+                f"Scan batch exceeded {SCAN_BATCH_TIMEOUT_SECONDS:g} seconds; "
+                f"{len(pending)} file(s) remained unfinished and cancellation "
+                f"succeeded for {cancelled} not-yet-running file(s)."
+            )
+
+        try:
+            result = self.api.finalize_scan([future.result() for future in self.futures])
+        except Exception as exc:
+            raise ScanError(f"Scan worker failed: {exc}") from exc
+
+        if strict and result.failures:
+            first = result.failures[0]
+            raise ScanError(
+                f"Scanning was incomplete: {len(result.failures)} of "
+                f"{result.scanned_files or len(self.futures)} file(s) failed "
+                f"(first error in {first.file_path}: {first.error}). "
+                "Is perl installed and the stats path correct?"
+            )
+
+        state = self.api.state_manager
+        state.set_stats_path(self.stats_path)
+        state.set_stats_pattern(self.stats_pattern)
+        state.set_scanned_variables([variable.to_dict() for variable in result.variables])
+        return result

--- a/ring5/_session.py
+++ b/ring5/_session.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import copy
 import shutil
 import tempfile
+import threading
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import pandas as pd
 
 from src.core.application_api import ApplicationAPI
-from src.core.models import RestoreReport, StatConfig
+from src.core.models import RestoreReport, ScanResult, StatConfig
 from src.core.models.data_models import ParseVariableConfig
 from src.core.models.shaper_models import ShaperStepConfig
 from src.core.models.visualization.engine import EngineMode
@@ -19,7 +20,7 @@ from src.parsing.parser_protocol import SimulationParser
 from src.web.pages.ui.plotting.base_plot import BasePlot
 from src.web.pages.ui.plotting.plot_factory import PlotFactory
 
-from ring5 import _export, _parse, _render
+from ring5 import _export, _parse, _render, _scan
 from ring5.errors import (
     ColumnNotFoundError,
     DataLoadError,
@@ -27,8 +28,10 @@ from ring5.errors import (
     ParseError,
     PipelineError,
     PortfolioError,
+    ScanError,
 )
 from ring5.figure_spec import FigureSpec
+from ring5._plot_validation import validate_plot_config
 
 PlotType = Literal[
     "bar",
@@ -64,6 +67,28 @@ def _rewrap_table(frame: pd.DataFrame) -> "Table":
     from ring5.data import Table as _Table
 
     return _Table(frame)
+
+
+def _remove_directory_when_settled(path: str, futures: list[Any]) -> None:
+    """Remove *path* now, or after every still-running future settles."""
+    pending = {id(future) for future in futures if not future.done()}
+    if not pending:
+        shutil.rmtree(path, ignore_errors=True)
+        return
+
+    lock = threading.Lock()
+
+    def settled(future: Any) -> None:
+        should_remove = False
+        with lock:
+            pending.discard(id(future))
+            should_remove = not pending
+        if should_remove:
+            shutil.rmtree(path, ignore_errors=True)
+
+    for future in futures:
+        if id(future) in pending:
+            future.add_done_callback(settled)
 
 
 def available_plot_types() -> tuple[str, ...]:
@@ -120,6 +145,7 @@ class Session:
         self.api = ApplicationAPI(plot_deserializer=PlotFactory.from_dict, parser=parser)
         # Temporary parse output is removed when the session closes.
         self._owned_tmpdirs: list[str] = []
+        self._parse_jobs: list[_parse.ParseJob] = []
 
     # lifecycle
     def __enter__(self) -> "Session":
@@ -131,9 +157,69 @@ class Session:
     def close(self) -> None:
         """Release this session's pending work (process pools stay up)."""
         self.api.cancel_pending_scans()
+        for job in self._parse_jobs:
+            job.cancel()
         for tmp in self._owned_tmpdirs:
-            shutil.rmtree(tmp, ignore_errors=True)
+            jobs = [job for job in self._parse_jobs if job.output_dir == tmp]
+            futures = [future for job in jobs for future in job.futures]
+            _remove_directory_when_settled(tmp, futures)
         self._owned_tmpdirs.clear()
+        self._parse_jobs.clear()
+
+    # scan
+    def scan_submit(
+        self,
+        stats_path: str,
+        *,
+        pattern: str = "stats.txt",
+        limit: int = 10,
+    ) -> _scan.ScanJob:
+        """Submit variable discovery and return a handle-based scan job.
+
+        Args:
+            stats_path: Root directory containing simulator statistics.
+            pattern: Statistics filename pattern.
+            limit: Maximum files to scan; zero scans all matching files up to
+                the global discovery ceiling.
+
+        Returns:
+            A submitted scan job that can be finalized or cancelled.
+
+        Raises:
+            ScanError: Discovery could not be submitted.
+        """
+        try:
+            futures = self.api.submit_scan_async(stats_path, pattern, limit=limit)
+        except (FileNotFoundError, OSError, RuntimeError, ValueError) as exc:
+            raise ScanError(str(exc)) from exc
+        return _scan.ScanJob(self.api, list(futures), stats_path, pattern)
+
+    def scan(
+        self,
+        stats_path: str,
+        *,
+        pattern: str = "stats.txt",
+        limit: int = 10,
+        strict: bool = True,
+    ) -> ScanResult:
+        """Discover variables in a statistics tree and wait for completion.
+
+        Args:
+            stats_path: Root directory containing simulator statistics.
+            pattern: Statistics filename pattern.
+            limit: Maximum files to scan; zero scans all matching files up to
+                the global discovery ceiling.
+            strict: Raise if any selected file fails to scan. When false,
+                return the partial result with its ``failures`` list.
+
+        Returns:
+            Aggregated immutable scan metadata.
+
+        Raises:
+            ScanError: Discovery failed, timed out, or was incomplete in
+                strict mode.
+        """
+        return self.scan_submit(stats_path, pattern=pattern, limit=limit).finalize(strict=strict)
 
     # parse
     def parse_submit(
@@ -193,6 +279,9 @@ class Session:
                 scanned_vars=scanned,
             )
         except (FileNotFoundError, ValueError, RuntimeError) as exc:
+            if output_dir is None:
+                shutil.rmtree(out_dir, ignore_errors=True)
+                self._owned_tmpdirs.remove(out_dir)
             raise ParseError(f"Parse submission failed: {exc}") from exc
 
         # Store parse provenance for portfolio restoration and replay.
@@ -209,7 +298,7 @@ class Session:
             )
         )
         sm.set_scanned_variables([v.to_dict() if hasattr(v, "to_dict") else v for v in scanned])
-        return _parse.ParseJob(
+        job = _parse.ParseJob(
             api=self.api,
             futures=list(batch.futures),
             var_names=list(batch.var_names),
@@ -218,6 +307,8 @@ class Session:
             stats_path=stats_path,
             stats_pattern=pattern,
         )
+        self._parse_jobs.append(job)
+        return job
 
     def parse(
         self,
@@ -381,6 +472,78 @@ class Session:
             raise DataValidationError(str(exc)) from exc
         return _rewrap_table(cleaned) if was_table else cleaned
 
+    def apply_operation(
+        self,
+        data: "pd.DataFrame | Table",
+        operation: str,
+        src1: str,
+        src2: str,
+        dest: str,
+    ) -> "pd.DataFrame | Table":
+        """Create a column using a registered binary arithmetic operation.
+
+        Args:
+            data: Input table or DataFrame.
+            operation: Arithmetic operation name or supported symbol.
+            src1: Left operand column.
+            src2: Right operand column.
+            dest: Destination column name.
+
+        Returns:
+            Transformed data of the same public type as ``data``.
+
+        Raises:
+            ColumnNotFoundError: An operand column is absent.
+            DataValidationError: The operation or destination is invalid.
+        """
+        frame, was_table = _unwrap_table(data)
+        _require_columns(frame, [src1, src2])
+        if not dest:
+            raise DataValidationError("Destination column name cannot be empty.")
+        try:
+            result = self.api.managers.apply_operation(frame, operation, src1, src2, dest)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise DataValidationError(str(exc)) from exc
+        return _rewrap_table(result) if was_table else result
+
+    def mix_columns(
+        self,
+        data: "pd.DataFrame | Table",
+        dest_col: str,
+        source_cols: list[str],
+        operation: str = "Sum",
+        separator: str = "_",
+    ) -> "pd.DataFrame | Table":
+        """Merge columns, including standard-deviation propagation.
+
+        Args:
+            data: Input table or DataFrame.
+            dest_col: Destination column name.
+            source_cols: Two or more columns to merge.
+            operation: ``Sum``, ``Mean``, ``Mean (Average)``, or
+                ``Concatenate``.
+            separator: Separator used by concatenation.
+
+        Returns:
+            Transformed data of the same public type as ``data``.
+
+        Raises:
+            ColumnNotFoundError: A source column is absent.
+            DataValidationError: The merge configuration is invalid.
+        """
+        frame, was_table = _unwrap_table(data)
+        _require_columns(frame, source_cols)
+        errors = self.api.managers.validate_merge_inputs(frame, source_cols, operation, dest_col)
+        if errors:
+            raise DataValidationError("; ".join(errors))
+        try:
+            result = self.api.managers.apply_mixer(
+                frame, dest_col, source_cols, operation, separator
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise DataValidationError(str(exc)) from exc
+        return _rewrap_table(result) if was_table else result
+
     # figures
     def create_plot(
         self,
@@ -411,11 +574,20 @@ class Session:
 
         resolved_type = _resolve_plot_type(plot_type)
         frame, _ = _unwrap_table(data)
+        if not isinstance(frame, pd.DataFrame):
+            raise DataValidationError("Plot data must be a pandas DataFrame or ring5.Table.")
+        try:
+            raw_config = config.to_config() if isinstance(config, FigureSpec) else dict(config)
+        except (TypeError, ValueError) as exc:
+            raise DataValidationError(f"Plot config must be a mapping: {exc}") from exc
+        validate_plot_config(resolved_type, frame, raw_config)
+
+        # Validation happens before registration so a rejected configuration
+        # cannot leave a broken plot behind in the session portfolio.
         plot = PlotService.create_plot(name or resolved_type, resolved_type, self.api.state_manager)
         if name is None:
             plot.name = f"{resolved_type}_{plot.plot_id}"
         plot.replace_processed_data(frame.copy())
-        raw_config = config.to_config() if isinstance(config, FigureSpec) else dict(config)
         # Plot configuration contains nested lists and dictionaries. Copy it so a
         # later caller mutation cannot silently change an already registered plot.
         plot.config = copy.deepcopy(raw_config)

--- a/ring5/cli.py
+++ b/ring5/cli.py
@@ -39,9 +39,11 @@ def _cmd_parse(args: argparse.Namespace) -> int:
             pattern=args.pattern,
             strict=not args.lenient,
         )
-    target = Path(args.output)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(result.csv_path, target)
+        # Session-owned parse directories are deleted on context exit, so
+        # materialize the requested output while the result still exists.
+        target = Path(args.output)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(result.csv_path, target)
     print(f"wrote {target}")
     if result.missing_stats:
         print(f"warning: no values parsed for: {', '.join(result.missing_stats)}")

--- a/ring5/shapers.py
+++ b/ring5/shapers.py
@@ -20,20 +20,34 @@ from src.core.services.shapers.impl.mean import Mean
 from src.core.services.shapers.impl.normalize import Normalize
 from src.core.services.shapers.impl.pivot import PivotLonger, PivotWider
 from src.core.services.shapers.impl.selector import Selector
+from src.core.services.shapers.impl.selector_algorithms.column_selector import ColumnSelector
+from src.core.services.shapers.impl.selector_algorithms.condition_selector import ConditionSelector
 from src.core.services.shapers.impl.selector_algorithms.group_cardinality_selector import (
     GroupCardinalitySelector,
 )
 from src.core.services.shapers.impl.selector_algorithms.group_predicate_selector import (
     GroupPredicateSelector,
 )
+from src.core.services.shapers.impl.selector_algorithms.item_selector import ItemSelector
 from src.core.services.shapers.impl.sort import Sort
 from src.core.services.shapers.impl.split_apply import SplitApply
 from src.core.services.shapers.impl.transformer import Transformer
+
+
+def available_shaper_types() -> tuple[str, ...]:
+    """Return every registered pipeline shaper identifier."""
+    from src.core.services.shapers.factory import ShaperFactory
+
+    return tuple(ShaperFactory.get_available_types())
+
 
 __all__ = [
     "Mean",
     "Normalize",
     "Selector",
+    "ColumnSelector",
+    "ConditionSelector",
+    "ItemSelector",
     "Sort",
     "SplitApply",
     "Transformer",
@@ -42,4 +56,5 @@ __all__ = [
     "DeriveColumn",
     "GroupCardinalitySelector",
     "GroupPredicateSelector",
+    "available_shaper_types",
 ]

--- a/src/parsing/gem5/impl/gem5_parser.py
+++ b/src/parsing/gem5/impl/gem5_parser.py
@@ -447,7 +447,16 @@ class Gem5Parser(SimulationParser):
         column_map: dict[str, list[str] | None] = {}
 
         # Use provided var_names to ensure consistent order
-        ordered_names: list[str] = var_names if var_names else list(results[0].keys())
+        ordered_names = list(var_names) if var_names else list(results[0].keys())
+        extra_names = sorted(
+            {
+                name
+                for result in results
+                for name, value in result.items()
+                if name not in ordered_names and not hasattr(value, "balance_content")
+            }
+        )
+        ordered_names.extend(extra_names)
 
         for var_name in ordered_names:
             # Search all results for the first occurrence of this variable

--- a/src/parsing/gem5/impl/strategies/config_aware.py
+++ b/src/parsing/gem5/impl/strategies/config_aware.py
@@ -13,11 +13,13 @@ Features:
 """
 
 import configparser
+import json
 import logging
 from pathlib import Path
 from typing import Any
 
 from src.parsing.gem5.impl.strategies.simple import SimpleStatsStrategy
+from src.parsing.gem5.impl.strategies.file_parser_strategy import INTERNAL_SIM_PATH_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -35,25 +37,32 @@ class ConfigAwareStrategy(SimpleStatsStrategy):
         """
         Augment results with config data.
         """
-        augmented_results = []
+        augmented_results: list[dict[str, Any]] = []
         for sim_result in results:
-            if "sim_path" not in sim_result:
-                # Should not happen if worker is correct, but safety first
-                augmented_results.append(sim_result)
-                continue
+            if INTERNAL_SIM_PATH_KEY not in sim_result:
+                raise RuntimeError("PARSER: config-aware result is missing simulation provenance.")
+            if "sim_path" in sim_result or "config_json" in sim_result:
+                raise ValueError(
+                    "PARSER: config-aware metadata columns collide with requested statistics."
+                )
 
-            sim_dir = Path(sim_result["sim_path"]).parent
+            sim_path = str(sim_result[INTERNAL_SIM_PATH_KEY])
+            sim_dir = Path(sim_path).parent
             config_path = sim_dir / "config.ini"
 
-            if config_path.exists():
-                logger.debug(f"PARSER: Found config at {config_path}")
-                config_data = self._parse_config(config_path)
-                # Build a NEW dict with the config merged in, rather than mutating
-                # the caller's result dict in place.
-                augmented_results.append({**sim_result, "config": config_data})
-            else:
-                logger.warning(f"PARSER: config.ini not found for {sim_result['sim_path']}")
-                augmented_results.append(sim_result)
+            if not config_path.is_file():
+                raise FileNotFoundError(f"PARSER: config.ini not found beside {sim_path}")
+
+            logger.debug("PARSER: Found config at %s", config_path)
+            config_data = self._parse_config(config_path)
+            public_result = {
+                key: value for key, value in sim_result.items() if key != INTERNAL_SIM_PATH_KEY
+            }
+            public_result["sim_path"] = sim_path
+            public_result["config_json"] = json.dumps(
+                config_data, sort_keys=True, separators=(",", ":")
+            )
+            augmented_results.append(public_result)
 
         return augmented_results
 
@@ -66,9 +75,11 @@ class ConfigAwareStrategy(SimpleStatsStrategy):
         """
         parser = configparser.ConfigParser()
         try:
-            parser.read(str(config_path))
+            loaded = parser.read(str(config_path))
+            if not loaded or not parser.sections():
+                raise configparser.Error("configuration contains no sections")
             # Convert ConfigParser to dict for easier handling
             return {section: dict(parser.items(section)) for section in parser.sections()}
         except (configparser.Error, OSError) as e:
             logger.error("PARSER: Failed to parse %s: %s", config_path, e)
-            return {}
+            raise RuntimeError(f"PARSER: Failed to parse {config_path}: {e}") from e

--- a/src/parsing/gem5/impl/strategies/file_parser_strategy.py
+++ b/src/parsing/gem5/impl/strategies/file_parser_strategy.py
@@ -20,6 +20,8 @@ from typing import Any, Protocol
 from src.core.models import StatConfig
 from src.parsing.gem5.impl.pool.parse_work import ParseWork
 
+INTERNAL_SIM_PATH_KEY = "__ring5_internal_sim_path"
+
 
 class FileParserStrategy(Protocol):
     """

--- a/src/parsing/gem5/impl/strategies/gem5_parse_work.py
+++ b/src/parsing/gem5/impl/strategies/gem5_parse_work.py
@@ -19,6 +19,7 @@ from src.core.common.safe_regex import (
 )
 from src.core.common.security_limits import MAX_PARSE_VARIABLES
 from src.parsing.gem5.impl.pool.parse_work import ParsedVarsDict, ParseWork
+from src.parsing.gem5.impl.strategies.file_parser_strategy import INTERNAL_SIM_PATH_KEY
 from src.parsing.gem5.impl.strategies.perl_worker_pool import get_worker_pool
 from src.parsing.gem5.types.type_mapper import TypeMapper
 
@@ -102,8 +103,15 @@ class Gem5ParseWork(ParseWork):
 
     @staticmethod
     def _request_key(var_id: str) -> str:
-        """Request key before the ``__`` separator (e.g. ``a__b`` -> ``a``)."""
-        return var_id.split("__", 1)[0]
+        """Return the concrete stat name requested from the Perl parser.
+
+        ``__get_summary`` is RING-5's only synthetic suffix.  Gem5 itself
+        legitimately uses double underscores in names (for example
+        ``MemDepUnit__0``), so splitting at the first ``__`` silently
+        truncated pattern-expanded aliases and left their values missing.
+        """
+        suffix = "__get_summary"
+        return var_id[: -len(suffix)] if var_id.endswith(suffix) else var_id
 
     @staticmethod
     def _numeric_pattern_id(pattern: str, concrete_name: str) -> str | None:
@@ -427,4 +435,6 @@ class Gem5ParseWork(ParseWork):
             subprocess.CalledProcessError: If Perl script fails
         """
         output: str = self._runPerlScript()
-        return self._processOutput(output, self._varsToParse)
+        result: ParsedVarsDict = dict(self._processOutput(output, self._varsToParse))
+        result[INTERNAL_SIM_PATH_KEY] = self._fileToParse
+        return result

--- a/src/parsing/gem5/impl/strategies/simple.py
+++ b/src/parsing/gem5/impl/strategies/simple.py
@@ -20,10 +20,12 @@ from src.core.common.security_limits import (
     MAX_PARSE_TOTAL_BYTES,
     MAX_PARSE_VARIABLES,
 )
+from src.core.common.safe_regex import SafeRegexError, numeric_pattern_id
 from src.core.common.utils import sanitize_log_value
 from src.core.models import StatConfig
 from src.parsing.framework.file_discovery import find_stats_files
 from src.parsing.gem5.impl.strategies.gem5_parse_work import Gem5ParseWork
+from src.parsing.gem5.impl.strategies.file_parser_strategy import INTERNAL_SIM_PATH_KEY
 from src.parsing.gem5.types.type_mapper import TypeMapper
 
 logger = logging.getLogger(__name__)
@@ -101,8 +103,13 @@ class SimpleStatsStrategy:
         return works
 
     def post_process(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Perform any post-processing on aggregated results."""
-        return results
+        """Remove worker-only provenance before writing the public CSV."""
+        processed: list[dict[str, Any]] = []
+        for result in results:
+            public_result = dict(result)
+            public_result.pop(INTERNAL_SIM_PATH_KEY, None)
+            processed.append(public_result)
+        return processed
 
     def _get_files(self, stats_path: str, stats_pattern: str) -> list[str]:
         """Find all stats files matching the pattern in the target path.
@@ -152,6 +159,8 @@ class SimpleStatsStrategy:
             # Validation logic kept from original parser
             if not name:
                 raise ValueError("PARSER: Variable config missing 'name'.")
+            if name == INTERNAL_SIM_PATH_KEY:
+                raise ValueError(f"PARSER: Variable name {name!r} is reserved for internal use.")
 
             if name in var_map:
                 raise RuntimeError(f"PARSER: Duplicate variable definition: {name}")
@@ -191,14 +200,36 @@ class SimpleStatsStrategy:
                 )
 
             if parsed_ids:
-                # Update repeat count for the logical variable (Spatial aggregation)
-                stat_obj = TypeMapper.create_stat(replace(var, repeat=n_ids))
+                # Resolve repeat count for the logical variable (spatial aggregation).
+                source_pattern = var.source_name or name
+                entry_ids: list[str] = []
+                try:
+                    entry_ids = [
+                        pattern_id
+                        for parsed_id in parsed_ids
+                        if (pattern_id := numeric_pattern_id(source_pattern, parsed_id)) is not None
+                    ]
+                except SafeRegexError:
+                    entry_ids = []
+                configured_entries = var.params.get("entries", [])
+                # Repeated scalar names are exposed by the scanner as a logical
+                # vector whose entries are the numeric IDs.  Each entry contains
+                # one value, so padding it to ``n_ids`` makes every mean NaN.
+                # True vector/distribution patterns still aggregate the same
+                # bucket across all concrete instances and retain repeat=n_ids.
+                scalar_pattern_vector = (
+                    var.type == "vector"
+                    and isinstance(configured_entries, list)
+                    and set(entry_ids) == set(configured_entries)
+                    and len(entry_ids) == n_ids
+                )
+                repeat = var.repeat if scalar_pattern_vector else n_ids
+                stat_obj = TypeMapper.create_stat(replace(var, repeat=repeat))
                 if n_ids > 50:
                     logger.warning(
-                        "PARSER: Variable '%s' has repeat=%d (from %d parsed_ids) — "
+                        "PARSER: Variable '%s' expands to %d concrete instances — "
                         "this may increase memory usage significantly.",
                         name,
-                        n_ids,
                         n_ids,
                     )
             else:

--- a/src/parsing/gem5/perl/fileParser.pl
+++ b/src/parsing/gem5/perl/fileParser.pl
@@ -14,6 +14,7 @@ my $filename = shift or die "Please provide a filename as an argument.\n";
 die "Please provide at least one filter as an argument.\n" unless @ARGV;
 # Filters for variable names
 setFilterRegexes(@ARGV);
+resetLineContext();
 # Open the statistics file with buffered I/O
 open(my $fh, '<:raw', $filename) or die "Could not open file '$filename' $!";
 

--- a/src/parsing/gem5/perl/fileParserServer.pl
+++ b/src/parsing/gem5/perl/fileParserServer.pl
@@ -94,6 +94,7 @@ while (my $command = <STDIN>) {
             print "END_PARSE\n";
             next;
         }
+        resetLineContext();
 
         # Open and parse file
         my $line_count = 0;

--- a/src/parsing/gem5/perl/libs/TypesFormatRegex.pm
+++ b/src/parsing/gem5/perl/libs/TypesFormatRegex.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Exporter 'import';
 our $VERSION = '1.00';
-our @EXPORT  = qw(parseAndPrintLineWithFormat setFilterRegexes classifyLine);
+our @EXPORT  = qw(parseAndPrintLineWithFormat setFilterRegexes classifyLine resetLineContext);
 
 # Imports from new modular packages
 use Scanning::RegexUtils qw(:all);
@@ -21,6 +21,60 @@ use Scanning::Type::Summary qw($summaryRegex);
 
 my $filtersRegexes;
 my @storedFilters;
+my %onelineHistogramMetadata;
+
+sub resetLineContext {
+    %onelineHistogramMetadata = ();
+}
+
+sub _rememberOnelineHistogramMetadata {
+    my ($line) = @_;
+    if ($line =~ /^($varNameRegex)::(bucket_size|max_bucket)\s+(-?\d+)$commentRegex$/) {
+        $onelineHistogramMetadata{$1}{$2} = int($3);
+        return 1;
+    }
+    return 0;
+}
+
+sub _classifyOnelineHistogram {
+    my ($line) = @_;
+    my $clean = removeCommentFromLine($line);
+    return undef unless $clean =~ /^($varNameRegex)\s+\|(.*)$/;
+
+    my $name = $1;
+    my $payload = $2;
+    my $metadata = $onelineHistogramMetadata{$name};
+    return undef unless defined $metadata;
+    die "Incomplete one-line histogram metadata for $name\n"
+        unless exists $metadata->{bucket_size} && exists $metadata->{max_bucket};
+
+    my $bucket_size = $metadata->{bucket_size};
+    my $max_bucket = $metadata->{max_bucket};
+    die "Invalid one-line histogram metadata for $name\n"
+        unless $bucket_size > 0 && $max_bucket >= 0;
+
+    my @groups = split /\s*\|\s*/, $payload;
+    my @values;
+    foreach my $group (@groups) {
+        die "Malformed one-line histogram bucket for $name: $group\n"
+            unless $group =~ /^\s*(-?\d+)\s+$floatRegex%\s+$floatRegex%\s*$/;
+        push @values, $1;
+    }
+
+    my $expected = int($max_bucket / $bucket_size) + 1;
+    die "One-line histogram bucket count mismatch for $name: expected $expected, found "
+        . scalar(@values) . "\n"
+        unless scalar(@values) == $expected;
+
+    my @entries;
+    for (my $index = 0; $index < @values; $index++) {
+        my $start = $index * $bucket_size;
+        my $end = $start + $bucket_size - 1;
+        $end = $max_bucket if $end > $max_bucket;
+        push @entries, { entry => "$start-$end", value => $values[$index] };
+    }
+    return { type => 'histogram', name => $name, entries => \@entries };
+}
 
 sub getRealVariableNameFromLine {
     my ($line) = @_;
@@ -152,6 +206,18 @@ sub parseAndPrintLineWithFormat {
     # Early return optimization: check filter first
     return unless $line =~ $filtersRegexes;
 
+    # Gem5's Stats::oneline histogram format writes its bucket geometry on
+    # preceding metadata lines, followed by one pipe-delimited row.  Consume
+    # the metadata rather than exposing it as fake vector buckets.
+    return if _rememberOnelineHistogramMetadata($line);
+    my $oneline = _classifyOnelineHistogram($line);
+    if (defined $oneline) {
+        foreach my $item (@{$oneline->{entries}}) {
+            print "histogram/$oneline->{name}::$item->{entry}/$item->{value}\n";
+        }
+        return;
+    }
+
     # Optimization: Check types in order of frequency (most common first)
     # and use elsif to avoid multiple regex matches
 
@@ -163,13 +229,13 @@ sub parseAndPrintLineWithFormat {
     elsif ($line =~ $vectorRegex) {
         print "vector/" . formatLine($line) . "\n";
     }
-    # Distribution
-    elsif ($line =~ $distRegex) {
-        print "distribution/" . formatLine($line) . "\n";
-    }
     # Histogram
     elsif ($line =~ $histogramRegex) {
         print "histogram/" . formatLine($line) . "\n";
+    }
+    # Distribution
+    elsif ($line =~ $distRegex) {
+        print "distribution/" . formatLine($line) . "\n";
     }
     # Summary
     elsif ($line =~ $summaryRegex) {
@@ -189,6 +255,12 @@ sub parseAndPrintLineWithFormat {
 
 sub classifyLine {
     my ($line) = @_;
+
+    if (_rememberOnelineHistogramMetadata($line)) {
+        return { type => 'oneline_metadata', name => undef, entry => undef };
+    }
+    my $oneline = _classifyOnelineHistogram($line);
+    return $oneline if defined $oneline;
 
     # Check types in order with explicit captures
 

--- a/src/parsing/gem5/perl/statsScanner.pl
+++ b/src/parsing/gem5/perl/statsScanner.pl
@@ -26,6 +26,7 @@ die "Invalid scanner line limit\n" unless $max_lines =~ /^\d+$/ && $max_lines > 
 # We access regexes indirectly by calling classifyLine provided by TypesFormatRegex.
 # We set a catch-all filter to scan all lines.
 TypesFormatRegex::setFilterRegexes(".*");
+TypesFormatRegex::resetLineContext();
 
 
 
@@ -104,9 +105,19 @@ while (my $line = <$fh>) {
     my $info = TypesFormatRegex::classifyLine($line);
     next unless $info;
 
+    next if $info->{type} eq 'oneline_metadata';
+
     my $name = $info->{name};
     my $type = $info->{type};
     my $entry = $info->{entry};
+
+    if ($info->{entries}) {
+        manageType($name, $type, \%discovered_vars);
+        foreach my $item (@{$info->{entries}}) {
+            addEntry($name, $item->{entry}, \%discovered_vars);
+        }
+        next;
+    }
 
     if ($type eq 'summary') {
         processSummary($name, $entry, \%discovered_vars);

--- a/tests/integration/test_engine_isolation.py
+++ b/tests/integration/test_engine_isolation.py
@@ -13,8 +13,11 @@ Two guarantees are pinned here:
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 import ring5
+
+pytestmark = pytest.mark.public_api
 
 
 def _grouped_stacked_config() -> dict:

--- a/tests/integration/test_ring5_api_completeness.py
+++ b/tests/integration/test_ring5_api_completeness.py
@@ -1,0 +1,242 @@
+"""Contract tests for the complete supported analysis workflow."""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import Future
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+import ring5
+from ring5._parse import ParseJob
+from ring5._scan import ScanJob
+from src.core.models import ScanFileResult, ScannedVariable, ScanResult
+
+pytestmark = pytest.mark.public_api
+
+
+def _write_stats_run(root: Path, body: str, config: str | None = None) -> Path:
+    run = root / "run"
+    run.mkdir(parents=True)
+    (run / "stats.txt").write_text(body)
+    if config is not None:
+        (run / "config.ini").write_text(config)
+    return run
+
+
+def test_scan_parse_and_config_aware_workflow(tmp_path: Path) -> None:
+    run = _write_stats_run(
+        tmp_path / "inputs",
+        "simTicks 123 # ticks\n",
+        "[system]\nnum_cpus = 4\ncpu_type = O3CPU\n",
+    )
+
+    with ring5.Session() as session:
+        job = session.scan_submit(str(run), limit=0)
+        scan = job.finalize()
+        assert scan.complete
+        assert [(variable.name, variable.type) for variable in scan.variables] == [
+            ("simTicks", "scalar")
+        ]
+
+        parsed = session.parse(
+            str(run),
+            ["simTicks"],
+            strategy="config_aware",
+            output_dir=str(tmp_path / "output"),
+        )
+
+    frame = pd.read_csv(parsed.csv_path)
+    assert frame.loc[0, "simTicks"] == 123
+    assert frame.loc[0, "sim_path"] == str(run / "stats.txt")
+    assert json.loads(frame.loc[0, "config_json"])["system"]["num_cpus"] == "4"
+
+
+def test_config_aware_missing_config_is_typed(tmp_path: Path) -> None:
+    run = _write_stats_run(tmp_path / "inputs", "simTicks 123 # ticks\n")
+    with ring5.Session() as session:
+        with pytest.raises(ring5.ParseError, match="config.ini not found"):
+            session.parse(
+                str(run),
+                ["simTicks"],
+                strategy="config_aware",
+                output_dir=str(tmp_path / "output"),
+            )
+
+
+def test_gem5_oneline_histogram_is_scanned_and_parsed(tmp_path: Path) -> None:
+    run = _write_stats_run(
+        tmp_path / "inputs",
+        "\n".join(
+            [
+                "system.delay::bucket_size 10 # geometry",
+                "system.delay::max_bucket 19 # geometry",
+                "system.delay::samples 5 # summary",
+                "system.delay | 3 60.00% 60.00% | 2 40.00% 100.00% # buckets",
+                "system.delay::total 5 # summary",
+            ]
+        )
+        + "\n",
+    )
+
+    with ring5.Session() as session:
+        scanned = session.scan(str(run), limit=0)
+        variable = next(value for value in scanned.variables if value.name == "system.delay")
+        assert variable.type == "histogram"
+        assert {"0-9", "10-19"} <= set(variable.entries)
+        parsed = session.parse(
+            str(run), [variable.name], output_dir=str(tmp_path / "output"), scan_limit=0
+        )
+
+    frame = pd.read_csv(parsed.csv_path)
+    assert frame.loc[0, "system.delay..0-9"] == 3
+    assert frame.loc[0, "system.delay..10-19"] == 2
+
+
+def test_scan_job_partial_and_timeout_are_typed(monkeypatch: pytest.MonkeyPatch) -> None:
+    good: Future[ScanFileResult] = Future()
+    good.set_result(ScanFileResult("good/stats.txt", [ScannedVariable(name="x", type="scalar")]))
+    bad_result = ScanFileResult("bad/stats.txt", error="scanner failed")
+    bad: Future[ScanFileResult] = Future()
+    bad.set_result(bad_result)
+    api = MagicMock()
+    api.finalize_scan.return_value = ScanResult(
+        variables=[ScannedVariable(name="x", type="scalar")],
+        failures=[bad_result],
+        scanned_files=2,
+    )
+    job = ScanJob(api, [good, bad], "runs", "stats.txt")
+
+    with pytest.raises(ring5.ScanError, match="1 of 2"):
+        job.finalize()
+    partial = job.finalize(strict=False)
+    assert not partial.complete
+    api.state_manager.set_scanned_variables.assert_called()
+
+    pending: Future[ScanFileResult] = Future()
+    monkeypatch.setattr("ring5._scan.SCAN_BATCH_TIMEOUT_SECONDS", 0)
+    with pytest.raises(ring5.ScanError, match="cancellation succeeded for 1"):
+        ScanJob(api, [pending], "runs", "stats.txt").finalize()
+    assert pending.cancelled()
+
+
+def test_session_close_defers_cleanup_for_running_parse(tmp_path: Path) -> None:
+    output = tmp_path / "owned"
+    output.mkdir()
+    running: Future[dict[str, Any]] = Future()
+    assert running.set_running_or_notify_cancel()
+    session = ring5.Session()
+    session._owned_tmpdirs.append(str(output))
+    session._parse_jobs.append(
+        ParseJob(
+            api=session.api,
+            futures=[running],
+            var_names=["x"],
+            output_dir=str(output),
+            strategy="simple",
+            stats_path="runs",
+            stats_pattern="stats.txt",
+        )
+    )
+
+    session.close()
+    assert output.exists()
+    running.set_result({})
+    assert not output.exists()
+    session.close()  # idempotent
+
+
+def test_manager_operations_preserve_dataframe_and_table() -> None:
+    frame = pd.DataFrame({"a": [2.0, 4.0], "b": [1.0, 2.0], "a.sd": [0.3, 0.4], "b.sd": [0.4, 0.3]})
+    with ring5.Session() as session:
+        divided = session.apply_operation(frame, "Division", "a", "b", "ratio")
+        assert isinstance(divided, pd.DataFrame)
+        assert divided["ratio"].tolist() == [2.0, 2.0]
+
+        mixed = session.mix_columns(ring5.Table(frame), "total", ["a", "b"])
+        assert isinstance(mixed, ring5.Table)
+        assert mixed.rows()[0]["total"] == 3.0
+        assert mixed.rows()[0]["total.sd"] == pytest.approx(0.5)
+
+        with pytest.raises(ring5.ColumnNotFoundError):
+            session.apply_operation(frame, "Sum", "missing", "b", "total")
+        with pytest.raises(ring5.DataValidationError, match="Invalid operation"):
+            session.mix_columns(frame, "total", ["a", "b"], operation="Nope")
+
+
+def test_public_registries_are_complete() -> None:
+    assert set(ring5.available_shaper_types()) == {
+        "mean",
+        "columnSelector",
+        "conditionSelector",
+        "itemSelector",
+        "normalize",
+        "pivotLonger",
+        "pivotWider",
+        "sort",
+        "splitApply",
+        "transformer",
+        "deriveColumn",
+        "groupCardinalitySelector",
+        "groupPredicateSelector",
+    }
+    assert ring5.ScanJob is ScanJob
+    assert ring5.ScanResult is ScanResult
+    assert ring5.ScannedVariable is ScannedVariable
+    assert ring5.ShaperStepConfig is not None
+
+
+@pytest.mark.parametrize(
+    ("plot_type", "config"),
+    [
+        ("bar", {"x": "x", "y": "y", "color": "group"}),
+        ("dual_axis_bar_dot", {"x": "x", "y_bar": "y", "y_dot": "z"}),
+        ("grouped_bar", {"x": "x", "y": "y", "group": "group"}),
+        ("grouped_stacked_bar", {"x": "x", "y_columns": ["y", "z"], "group": "group"}),
+        ("heatmap", {"x": "x", "metric_columns": ["y", "z"], "facet_col": "group"}),
+        ("histogram", {"histogram_variable": "latency", "group_by": "group"}),
+        ("line", {"x": "x", "y": "y", "color": "group"}),
+        ("scatter", {"x": "x", "y": "y", "color": "group"}),
+        ("stacked_bar", {"x": "x", "y_columns": ["y", "z"]}),
+    ],
+)
+def test_every_registered_plot_accepts_validated_config(
+    plot_type: str, config: dict[str, Any]
+) -> None:
+    frame = pd.DataFrame(
+        {
+            "x": ["a", "b"],
+            "group": ["one", "two"],
+            "y": [1.0, 2.0],
+            "z": [2.0, 3.0],
+            "latency..0-9": [2.0, 3.0],
+            "latency..10-19": [1.0, 4.0],
+        }
+    )
+    with ring5.Session() as session:
+        plot = session.create_plot(plot_type, data=frame, config=config)
+        assert plot.plot_type == plot_type
+        assert session.render(plot, engine="plotly") is not None
+        assert session.render(plot, engine="matplotlib") is not None
+
+
+def test_invalid_plot_config_does_not_register_and_render_errors_are_typed() -> None:
+    frame = pd.DataFrame({"x": ["a"], "y": [1.0]})
+    with ring5.Session() as session:
+        with pytest.raises(ring5.DataValidationError, match="field 'y'"):
+            session.create_plot("bar", data=frame, config={"x": "x"})
+        assert session.plots == []
+
+        with pytest.raises(ring5.ColumnNotFoundError):
+            session.create_plot("bar", data=frame, config={"x": "x", "y": "missing"})
+        assert session.plots == []
+
+        plot = session.create_plot("bar", data=frame, config={"x": "x", "y": "y"})
+        plot.config = {"x": "x"}
+        with pytest.raises(ring5.RenderError, match="Could not render plot") as error:
+            session.render(plot, engine="plotly")
+        assert isinstance(error.value.__cause__, KeyError)

--- a/tests/integration/test_ring5_public_api.py
+++ b/tests/integration/test_ring5_public_api.py
@@ -13,7 +13,7 @@ import ring5
 
 DATA_ROOT = Path(__file__).parent.parent / "data" / "results-micro26-sens"
 
-pytestmark = pytest.mark.xdist_group("ring5_portfolios")
+pytestmark = [pytest.mark.xdist_group("ring5_portfolios"), pytest.mark.public_api]
 
 
 def _first_stats_subtree() -> Path:
@@ -121,11 +121,8 @@ class TestFullWorkflow:
             if vector is not None:
                 assert vector.name not in result.missing_stats
 
-            # The pattern variable expanded (is_regex was enabled) and
-            # produced its per-index entry columns — exact parity with the
-            # web UI's dict path. NOTE: aggregated-pattern VALUES are a
-            # known pre-existing parser limitation shared with the web path
-            # (verified identical), so values are not asserted here.
+            # The pattern variable expanded (is_regex was enabled), produced
+            # its per-index entry columns, and retained real values.
             if pattern is not None:
                 df = pd.read_csv(result.csv_path)
                 pattern_cols = [c for c in df.columns if c.startswith(f"{pattern.name}.")]
@@ -133,6 +130,7 @@ class TestFullWorkflow:
                     "pattern variable produced no columns — is_regex was "
                     "not enabled on the way to the parser"
                 )
+                assert bool(df[pattern_cols].notna().any().any())
 
     def test_parse_empty_dir_raises_typed(self, tmp_path: Path) -> None:
         """The boundary normalizes the core FileNotFoundError to ScanError."""

--- a/tests/unit/test_category_groups.py
+++ b/tests/unit/test_category_groups.py
@@ -10,6 +10,8 @@ import pytest
 from src.web.pages.ui.plotting.utils.grouped_bar_utils import GroupedBarUtils
 from ring5.figure_spec import FigureSpec, FigureSpecBuilder
 
+pytestmark = pytest.mark.public_api
+
 CATS = ["a", "b", "c"]
 GROUPS = {"a": "G1", "b": "G1", "c": "G2"}
 

--- a/tests/unit/test_dual_axis_per_group_api.py
+++ b/tests/unit/test_dual_axis_per_group_api.py
@@ -12,6 +12,7 @@ import math
 
 import matplotlib
 import pandas as pd
+import pytest
 
 from src.core.models.visualization.trace_config import LineTraceConfig
 from src.web.pages.ui.plotting.utils.grouped_stacked_bar_helpers import (
@@ -22,6 +23,8 @@ from src.web.rendering.matplotlib_trace_renderer import MatplotlibTraceRenderer
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
+
+pytestmark = pytest.mark.public_api
 
 # FigureSpec / DualAxisOpts -> flat config
 

--- a/tests/unit/test_export_logic.py
+++ b/tests/unit/test_export_logic.py
@@ -12,6 +12,8 @@ import pytest
 
 import ring5
 
+pytestmark = pytest.mark.public_api
+
 
 @pytest.fixture
 def session() -> Any:

--- a/tests/unit/test_figure_builder.py
+++ b/tests/unit/test_figure_builder.py
@@ -11,6 +11,8 @@ from ring5.figure_spec import (
     ReferenceLineOpts,
 )
 
+pytestmark = pytest.mark.public_api
+
 
 class TestFigureSpecBuilder:
     def test_chaining_returns_self(self) -> None:

--- a/tests/unit/test_figure_spec.py
+++ b/tests/unit/test_figure_spec.py
@@ -6,6 +6,8 @@ import pytest
 
 from ring5.figure_spec import FigureSpec, LegendOpts, ReferenceLineOpts
 
+pytestmark = pytest.mark.public_api
+
 
 class TestFigureSpecToConfig:
     """FigureSpec.to_config emits the flat keys the renderer expects."""

--- a/tests/unit/test_parser_data_source_services.py
+++ b/tests/unit/test_parser_data_source_services.py
@@ -100,21 +100,23 @@ class TestConfigAwareStrategy:
     """Tests for configuration discovery and parsing failures."""
 
     def test_post_process_no_sim_path(self) -> None:
-        """Result without sim_path key — should be appended as-is."""
+        """Worker results without internal provenance fail visibly."""
         from src.parsing.gem5.impl.strategies.config_aware import (
             ConfigAwareStrategy,
         )
 
         strategy = ConfigAwareStrategy()
         results = [{"some_data": 123}]
-        out = strategy.post_process(results)
-        assert len(out) == 1
-        assert out[0] == {"some_data": 123}
+        with pytest.raises(RuntimeError, match="missing simulation provenance"):
+            strategy.post_process(results)
 
     def test_post_process_config_found(self, tmp_path: Path) -> None:
         """Result with sim_path pointing to existing config.ini."""
         from src.parsing.gem5.impl.strategies.config_aware import (
             ConfigAwareStrategy,
+        )
+        from src.parsing.gem5.impl.strategies.file_parser_strategy import (
+            INTERNAL_SIM_PATH_KEY,
         )
 
         # Create a mock config.ini
@@ -125,29 +127,29 @@ class TestConfigAwareStrategy:
         stats_path.write_text("dummy")
 
         strategy = ConfigAwareStrategy()
-        results = [{"sim_path": str(stats_path), "data": "abc"}]
+        results = [{INTERNAL_SIM_PATH_KEY: str(stats_path), "data": "abc"}]
         out = strategy.post_process(results)
 
         assert len(out) == 1
-        assert "config" in out[0]
-        assert "system" in out[0]["config"]
-        assert out[0]["config"]["system"]["cpu_type"] == "O3CPU"
+        assert out[0]["sim_path"] == str(stats_path)
+        assert '"cpu_type":"O3CPU"' in out[0]["config_json"]
 
     def test_post_process_config_not_found(self, tmp_path: Path) -> None:
         """Result with sim_path but no config.ini in the directory."""
         from src.parsing.gem5.impl.strategies.config_aware import (
             ConfigAwareStrategy,
         )
+        from src.parsing.gem5.impl.strategies.file_parser_strategy import (
+            INTERNAL_SIM_PATH_KEY,
+        )
 
         stats_path = tmp_path / "stats.txt"
         stats_path.write_text("dummy")
 
         strategy = ConfigAwareStrategy()
-        results = [{"sim_path": str(stats_path), "data": "abc"}]
-        out = strategy.post_process(results)
-
-        assert len(out) == 1
-        assert "config" not in out[0]
+        results = [{INTERNAL_SIM_PATH_KEY: str(stats_path), "data": "abc"}]
+        with pytest.raises(FileNotFoundError, match="config.ini not found"):
+            strategy.post_process(results)
 
     def test_parse_config_error_handling(self, tmp_path: Path) -> None:
         """_parse_config handles malformed config gracefully."""
@@ -165,7 +167,7 @@ class TestConfigAwareStrategy:
         assert "section1" in result
 
     def test_parse_config_unreadable(self, tmp_path: Path) -> None:
-        """_parse_config returns empty dict on read error."""
+        """An empty configuration is rejected rather than silently emitted."""
         from src.parsing.gem5.impl.strategies.config_aware import (
             ConfigAwareStrategy,
         )
@@ -176,8 +178,8 @@ class TestConfigAwareStrategy:
         config_path.write_text("")  # Empty is fine for configparser
 
         strategy = ConfigAwareStrategy()
-        result = strategy._parse_config(config_path)
-        assert isinstance(result, dict)
+        with pytest.raises(RuntimeError, match="contains no sections"):
+            strategy._parse_config(config_path)
 
 
 # Parse work contract
@@ -1951,5 +1953,5 @@ class TestConfigAwareParseConfigException:
             mock_parser.read.side_effect = configparser.Error("parse error")
             mock_cp.return_value = mock_parser
 
-            result = strategy._parse_config(config_path)
-            assert result == {}
+            with pytest.raises(RuntimeError, match="parse error"):
+                strategy._parse_config(config_path)

--- a/tests/unit/test_parser_strategies.py
+++ b/tests/unit/test_parser_strategies.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -158,21 +159,20 @@ class TestSimpleStatsStrategy:
 
 class TestConfigAwareStrategy:
 
-    def test_augment_results(self) -> None:
-        raw_results = [{"sim_path": "/data/run1/stats.txt", "ipc": 1.5}]
+    def test_augment_results(self, tmp_path: Path) -> None:
+        from src.parsing.gem5.impl.strategies.file_parser_strategy import (
+            INTERNAL_SIM_PATH_KEY,
+        )
+
+        stats_path = tmp_path / "stats.txt"
+        stats_path.write_text("dummy")
+        (tmp_path / "config.ini").write_text("[system]\ncores = 4\n")
+        raw_results = [{INTERNAL_SIM_PATH_KEY: str(stats_path), "ipc": 1.5}]
 
         strategy = ConfigAwareStrategy()
+        results = strategy.post_process(raw_results)
 
-        with patch.object(strategy, "_parse_config") as mock_parse_config:
-            with patch("src.parsing.gem5.impl.strategies.config_aware.Path") as mock_path_cls:
-                mock_config_path = MagicMock()
-                mock_config_path.exists.return_value = True
-                mock_path_cls.return_value.parent.__truediv__.return_value = mock_config_path
-
-                mock_parse_config.return_value = {"system": {"cores": "4"}}
-
-                results = strategy.post_process(raw_results)
-
-                assert len(results) == 1
-                assert results[0]["ipc"] == 1.5
-                assert results[0]["config"]["system"]["cores"] == "4"
+        assert len(results) == 1
+        assert results[0]["ipc"] == 1.5
+        assert results[0]["sim_path"] == str(stats_path)
+        assert results[0]["config_json"] == '{"system":{"cores":"4"}}'

--- a/tests/unit/test_public_parse_limits.py
+++ b/tests/unit/test_public_parse_limits.py
@@ -10,6 +10,8 @@ from ring5._parse import ParseJob, build_stat_configs
 from ring5.errors import ParseError, ScanError
 from src.core.models import ScanFileResult, ScannedVariable, ScanResult
 
+pytestmark = pytest.mark.public_api
+
 
 def test_build_stat_configs_rejects_partial_scan() -> None:
     api = MagicMock()

--- a/tests/unit/test_ring5_cli.py
+++ b/tests/unit/test_ring5_cli.py
@@ -12,7 +12,7 @@ from ring5.cli import build_parser, main
 
 # Shares the conftest `portfolios_dir` patching with the public-api suite —
 # keep both files in one xdist group so they never interleave across workers.
-pytestmark = pytest.mark.xdist_group("ring5_portfolios")
+pytestmark = [pytest.mark.xdist_group("ring5_portfolios"), pytest.mark.public_api]
 
 
 class TestParserStructure:
@@ -38,6 +38,20 @@ class TestDoctorCommand:
         out = capsys.readouterr().out
         assert "dependency check" in out
         assert code in (0, 1)  # 1 when an optional binary is absent
+
+
+class TestParseCommand:
+    def test_parse_materializes_session_owned_output(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        run = tmp_path / "run"
+        run.mkdir()
+        (run / "stats.txt").write_text("simTicks 42 # ticks\n")
+        output = tmp_path / "result.csv"
+
+        assert main(["parse", str(run), "-v", "simTicks", "-o", str(output)]) == 0
+        assert pd.read_csv(output).loc[0, "simTicks"] == 42
+        assert "wrote" in capsys.readouterr().out
 
 
 class TestRenderCommand:

--- a/tests/unit/test_ring5_convenience_api.py
+++ b/tests/unit/test_ring5_convenience_api.py
@@ -9,6 +9,8 @@ import pytest
 import ring5
 import ring5.shapers as shapers
 
+pytestmark = pytest.mark.public_api
+
 
 class TestTable:
     """The public table wrapper keeps common scripts pandas-independent."""
@@ -84,6 +86,9 @@ def test_shapers_are_available_from_the_supported_module() -> None:
         "Mean",
         "Normalize",
         "Selector",
+        "ColumnSelector",
+        "ConditionSelector",
+        "ItemSelector",
         "Sort",
         "SplitApply",
         "Transformer",
@@ -92,6 +97,7 @@ def test_shapers_are_available_from_the_supported_module() -> None:
         "DeriveColumn",
         "GroupCardinalitySelector",
         "GroupPredicateSelector",
+        "available_shaper_types",
     }
 
     assert expected == set(shapers.__all__)

--- a/tests/unit/test_ring5_coverage_edges.py
+++ b/tests/unit/test_ring5_coverage_edges.py
@@ -1,0 +1,455 @@
+"""Edge contracts that keep the public API's exact coverage gate honest."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import runpy
+import sys
+import warnings
+from concurrent.futures import Future
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+from kaleido.errors import ChromeNotFoundError
+from matplotlib.figure import Figure
+
+import ring5
+import ring5.cli as ring5_cli
+from ring5 import _doctor, _export, _parse, _plot_validation, _portfolio
+from ring5._session import Session, _remove_directory_when_settled
+from ring5.errors import Ring5Error
+from ring5.figure_spec import DualAxisOpts, FigureSpec, FigureSpecBuilder, LegendOpts
+from src.core.models import RestoreReport, ScanFileResult, ScanResult, StatConfig
+from src.parsing.gem5.models import Gem5ScannedVariable
+
+pytestmark = pytest.mark.public_api
+
+
+def _future(value: Any = None, error: Exception | None = None) -> Future[Any]:
+    future: Future[Any] = Future()
+    if error is not None:
+        future.set_exception(error)
+    else:
+        future.set_result(value)
+    return future
+
+
+def test_lazy_module_fallback_directory_and_shutdown() -> None:
+    assert "Session" in dir(ring5)
+    assert ring5.__getattr__("Session") is Session
+    ring5.shutdown()
+
+    with patch("importlib.metadata.version", side_effect=ring5.PackageNotFoundError):
+        reloaded = importlib.reload(ring5)
+        assert reloaded.__version__ == "0.0.0"
+    importlib.reload(ring5)
+
+
+def test_doctor_report_and_browser_fallbacks() -> None:
+    found = _doctor.DependencyStatus("x", True, "/x", "tests", "install")
+    missing = _doctor.DependencyStatus("y", False, None, "tests", "install y")
+    all_found = _doctor.DoctorReport(found, found, found)
+    partial = _doctor.DoctorReport(found, missing, missing)
+    assert all_found.all_found
+    assert not partial.all_found
+    assert "install y" in str(partial)
+
+    real_import = builtins.__import__
+
+    def fail_choreographer(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "choreographer.browsers.chromium":
+            raise ImportError("moved")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fail_choreographer):
+        with patch("ring5._doctor.shutil.which", side_effect=lambda name: f"/{name}"):
+            assert _doctor._find_chrome() == "/chrome"
+        with patch("ring5._doctor.shutil.which", return_value=None):
+            assert _doctor._find_chrome() is None
+
+
+def test_export_error_normalization(tmp_path: Path) -> None:
+    plotly = go.Figure()
+    mpl = Figure()
+
+    with patch("ring5._export.plotly_download_bytes", side_effect=ChromeNotFoundError("chrome")):
+        with pytest.raises(ring5.DependencyMissingError):
+            _export.export_bytes(plotly, "png")
+    with patch("ring5._export.plotly_download_bytes", side_effect=ValueError("bad image")):
+        with pytest.raises(ring5.ExportError, match="bad image"):
+            _export.export_bytes(plotly, "png")
+    with patch("ring5._export.matplotlib_download_bytes", side_effect=RuntimeError("xelatex gone")):
+        with pytest.raises(ring5.DependencyMissingError):
+            _export.export_bytes(mpl, "pgf")
+    with patch("ring5._export.matplotlib_download_bytes", side_effect=ValueError("bad figure")):
+        with pytest.raises(ring5.ExportError, match="bad figure"):
+            _export.export_bytes(mpl, "pdf")
+    with pytest.raises(ring5.ExportError, match="Cannot export object"):
+        _export.export_bytes(object(), "pdf")  # type: ignore[arg-type]
+
+    with patch("pathlib.Path.write_bytes", side_effect=OSError("read only")):
+        with pytest.raises(ring5.ExportError, match="read only"):
+            _export.export_file(mpl, str(tmp_path / "out.pdf"))
+
+
+def _parse_job(api: MagicMock, futures: list[Future[Any]]) -> _parse.ParseJob:
+    return _parse.ParseJob(api, futures, ["x"], "out", "simple", "runs", "stats.txt")
+
+
+def test_parse_job_failure_edges(tmp_path: Path) -> None:
+    api = MagicMock()
+    with pytest.raises(ring5.ParseError, match="worker failed"):
+        _parse_job(api, [_future(error=RuntimeError("boom"))]).finalize()
+
+    api.finalize_parsing.return_value = None
+    with pytest.raises(ring5.ParseError, match="produced no CSV"):
+        _parse_job(api, [_future({})]).finalize()
+
+    api.finalize_parsing.side_effect = None
+    api.finalize_parsing.return_value = str(tmp_path / "result.csv")
+    with patch("ring5._parse.pd.read_csv", side_effect=UnicodeError("encoding")):
+        with pytest.raises(ring5.ParseError, match="validate parser output"):
+            _parse_job(api, [_future({})]).finalize()
+
+    csv_path = tmp_path / "missing.csv"
+    pd.DataFrame({"x": [float("nan")]}).to_csv(csv_path, index=False)
+    api.finalize_parsing.return_value = str(csv_path)
+    with pytest.raises(ring5.MissingStatError) as error:
+        _parse_job(api, [_future({})]).finalize()
+    assert error.value.missing == ["x"]
+    assert _parse._find_missing_stats(str(csv_path), ["x", "absent"]) == ["x", "absent"]
+
+
+def test_build_stat_configs_explicit_and_distribution_metadata() -> None:
+    api = MagicMock()
+    api.submit_scan_async.side_effect = OSError("cannot scan")
+    with pytest.raises(ring5.ScanError, match="cannot scan"):
+        _parse.build_stat_configs(api, "runs", ["x"])
+
+    distribution = Gem5ScannedVariable(
+        name="dist", type="distribution", entries=["0"], minimum=0, maximum=4
+    )
+    api.submit_scan_async.side_effect = None
+    api.submit_scan_async.return_value = [_future(ScanFileResult("stats", [distribution]))]
+    api.finalize_scan.return_value = ScanResult([distribution], scanned_files=1)
+    configs, _ = _parse.build_stat_configs(
+        api,
+        "runs",
+        [
+            StatConfig(name=r"cpu\d+", type="scalar"),
+            StatConfig(name="plain", type="scalar"),
+            "dist",
+        ],
+    )
+    assert configs[0].is_regex  # type: ignore[union-attr]
+    assert not configs[1].is_regex  # type: ignore[union-attr]
+    assert configs[2] == {
+        "name": "dist",
+        "type": "distribution",
+        "entries": ["0"],
+        "minimum": 0,
+        "maximum": 4,
+    }
+
+
+def test_plot_validation_rejects_each_invalid_shape() -> None:
+    frame = pd.DataFrame({"x": ["a"], "y": [1.0], "latency..0-9.sd": [1.0]})
+    with pytest.raises(ring5.DataValidationError, match="non-empty string"):
+        _plot_validation.validate_plot_config("bar", frame, {"x": 1, "y": "y"})
+    with pytest.raises(ring5.DataValidationError, match="non-empty list"):
+        _plot_validation.validate_plot_config("stacked_bar", frame, {"x": "x", "y_columns": []})
+    with pytest.raises(ring5.ColumnNotFoundError):
+        _plot_validation.validate_plot_config(
+            "stacked_bar", frame, {"x": "x", "y_columns": ["missing"]}
+        )
+    with pytest.raises(ring5.DataValidationError, match="histogram_variable"):
+        _plot_validation.validate_plot_config("histogram", frame, {"histogram_variable": 1})
+    with pytest.raises(ring5.DataValidationError, match="No histogram bucket"):
+        _plot_validation.validate_plot_config("histogram", frame, {"histogram_variable": "latency"})
+    with pytest.raises(ring5.DataValidationError, match="optional"):
+        _plot_validation.validate_plot_config(
+            "grouped_bar", frame, {"x": "x", "y": "y", "group": 1}
+        )
+    with pytest.raises(ring5.DataValidationError, match="optional non-empty"):
+        _plot_validation.validate_plot_config(
+            "grouped_stacked_bar",
+            frame,
+            {"x": "x", "y_columns": ["y"], "y_columns_right": []},
+        )
+
+
+def _portfolio_session(plots: list[Any], report: RestoreReport | None = None) -> MagicMock:
+    session = MagicMock()
+    session.__enter__.return_value = session
+    session.__exit__.return_value = None
+    session.load_portfolio.return_value = report or RestoreReport(data_restored=True)
+    session.plots = plots
+    session.render.return_value = object()
+    session.export.side_effect = lambda _fig, path, **_kwargs: path
+    return session
+
+
+def test_portfolio_replay_edges(tmp_path: Path) -> None:
+    with pytest.raises(ring5.PortfolioError, match="Unknown engine"):
+        _portfolio.render_portfolio("p", str(tmp_path), engine="bad")  # type: ignore[arg-type]
+
+    for report in (RestoreReport(), RestoreReport(plots_skipped=["broken plot"])):
+        session = _portfolio_session([], report)
+        with patch("ring5._portfolio.Session", return_value=session):
+            with pytest.raises(ring5.PortfolioError, match="No plots restored"):
+                _portfolio.render_portfolio("p", str(tmp_path))
+
+    plots = [
+        SimpleNamespace(name="same/name", plot_id=1),
+        SimpleNamespace(name="same_name", plot_id=2),
+    ]
+    session = _portfolio_session(plots)
+    with patch("ring5._portfolio.Session", return_value=session):
+        written = _portfolio.render_portfolio("p", str(tmp_path))
+    assert written[0] != written[1]
+    assert written[1].endswith("_2.pdf")
+
+    session = _portfolio_session([SimpleNamespace(name="bad", plot_id=1)])
+    session.render.side_effect = Ring5Error("render failed")
+    with patch("ring5._portfolio.Session", return_value=session):
+        with pytest.raises(ring5.PortfolioError, match="Rendering plot 'bad'"):
+            _portfolio.render_portfolio("p", str(tmp_path))
+
+
+def test_scan_cancel_and_worker_error() -> None:
+    pending: Future[ScanFileResult] = Future()
+    api = MagicMock()
+    ring5.ScanJob(api, [pending], "runs", "stats.txt").cancel()
+    assert pending.cancelled()
+    ring5.ScanJob(api, [], "runs", "stats.txt").cancel()
+
+    with pytest.raises(ring5.ScanError, match="worker failed"):
+        ring5.ScanJob(
+            api, [_future(error=RuntimeError("scan boom"))], "runs", "stats.txt"
+        ).finalize()
+
+
+def test_session_lifecycle_and_submission_edges(tmp_path: Path) -> None:
+    done = _future({})
+    running: Future[dict[str, Any]] = Future()
+    assert running.set_running_or_notify_cancel()
+    output = tmp_path / "deferred"
+    output.mkdir()
+    _remove_directory_when_settled(str(output), [done, running])
+    assert output.exists()
+    running.set_result({})
+    assert not output.exists()
+
+    first: Future[dict[str, Any]] = Future()
+    second: Future[dict[str, Any]] = Future()
+    assert first.set_running_or_notify_cancel()
+    assert second.set_running_or_notify_cancel()
+    two_step = tmp_path / "two-step"
+    two_step.mkdir()
+    _remove_directory_when_settled(str(two_step), [first, second])
+    first.set_result({})
+    assert two_step.exists()
+    second.set_result({})
+    assert not two_step.exists()
+
+    session = Session()
+    with patch.object(session.api, "submit_scan_async", side_effect=OSError("scan submit")):
+        with pytest.raises(ring5.ScanError, match="scan submit"):
+            session.scan_submit("runs")
+
+    with patch("ring5._session._parse.build_stat_configs", return_value=([], [])):
+        with patch.object(
+            session.api, "submit_parse_async", side_effect=ValueError("parse submit")
+        ):
+            with pytest.raises(ring5.ParseError, match="parse submit"):
+                session.parse_submit("runs", [])
+            user_output = tmp_path / "user-output"
+            with pytest.raises(ring5.ParseError, match="parse submit"):
+                session.parse_submit("runs", [], output_dir=str(user_output))
+
+    with patch.object(session.api, "load_data", return_value=None):
+        with patch.object(session.api.state_manager, "get_data", return_value=None):
+            with pytest.raises(ring5.DataLoadError, match="produced no data"):
+                session.load("empty.csv")
+
+    with patch.object(session.api, "apply_shapers", side_effect=ValueError("bad pipeline")):
+        with pytest.raises(ring5.PipelineError, match="bad pipeline"):
+            session.shape(pd.DataFrame({"x": [1]}), [])
+    session.close()
+
+
+def test_session_manager_edge_paths() -> None:
+    frame = pd.DataFrame({"group": ["a", "a", "b"], "x": [1.0, 3.0, 10.0], "y": [2, 4, 8]})
+    with Session() as session:
+        reduced = session.reduce_seeds(ring5.Table(frame), ["group"], ["x"])
+        assert isinstance(reduced, ring5.Table)
+        with pytest.raises(ring5.DataValidationError):
+            session.reduce_seeds(frame, [], [])
+        with patch.object(session.api.managers, "reduce_seeds", side_effect=ValueError("reduce")):
+            with pytest.raises(ring5.DataValidationError, match="reduce"):
+                session.reduce_seeds(frame, ["group"], ["x"])
+
+        assert isinstance(session.remove_outliers(ring5.Table(frame), "x"), ring5.Table)
+        with patch.object(
+            session.api.managers, "remove_outliers", side_effect=ValueError("outliers")
+        ):
+            with pytest.raises(ring5.DataValidationError, match="outliers"):
+                session.remove_outliers(frame, "x")
+
+        with pytest.raises(ring5.DataValidationError, match="cannot be empty"):
+            session.apply_operation(frame, "Sum", "x", "y", "")
+        with pytest.raises(ring5.DataValidationError, match="Unknown operation"):
+            session.apply_operation(frame, "Nope", "x", "y", "z")
+        assert isinstance(
+            session.apply_operation(ring5.Table(frame), "Sum", "x", "y", "z"), ring5.Table
+        )
+
+        with patch.object(session.api.managers, "apply_mixer", side_effect=ValueError("mixer")):
+            with pytest.raises(ring5.DataValidationError, match="mixer"):
+                session.mix_columns(frame, "z", ["x", "y"])
+
+
+def test_session_plot_and_portfolio_error_edges() -> None:
+    with Session() as session:
+        with pytest.raises(ring5.DataValidationError, match="Plot data"):
+            session.create_plot(
+                "bar", data=[], config={"x": "x", "y": "y"}  # type: ignore[arg-type]
+            )
+        with pytest.raises(ring5.DataValidationError, match="must be a mapping"):
+            session.create_plot(
+                "bar", data=pd.DataFrame({"x": [1], "y": [2]}), config=1  # type: ignore[arg-type]
+            )
+
+        with patch.object(session.api.data_services, "save_portfolio", side_effect=OSError("disk")):
+            with pytest.raises(ring5.PortfolioError, match="could not be saved"):
+                session.save_portfolio("p")
+        with patch.object(
+            session.api.data_services, "load_portfolio", side_effect=ValueError("json")
+        ):
+            with pytest.raises(ring5.PortfolioError, match="could not be read"):
+                session.load_portfolio("p")
+        with patch.object(session.api.data_services, "load_portfolio", return_value={}):
+            with patch.object(
+                session.api.state_manager, "restore_session", side_effect=KeyError("schema")
+            ):
+                with pytest.raises(ring5.PortfolioError, match="could not be restored"):
+                    session.load_portfolio("p")
+
+
+def test_cli_warning_restore_details_file_error_and_module_entry(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.csv"
+    source.write_text("x\nNaN\n")
+    fake_session = MagicMock()
+    fake_session.__enter__.return_value = fake_session
+    fake_session.__exit__.return_value = None
+    fake_session.parse.return_value = _parse.ParseResult(str(source), ["x"])
+    with patch("ring5._session.Session", return_value=fake_session):
+        assert (
+            ring5_cli.main(
+                ["parse", "runs", "-v", "x", "-o", str(tmp_path / "out.csv"), "--lenient"]
+            )
+            == 0
+        )
+    assert "warning" in capsys.readouterr().out
+
+    fake_session.load_portfolio.return_value = RestoreReport(
+        data_error="bad csv", parse_variables_skipped=2
+    )
+    with patch("ring5._session.Session", return_value=fake_session):
+        assert ring5_cli.main(["upgrade", "p"]) == 2
+    error_text = capsys.readouterr().err
+    assert "bad csv" in error_text and "2 malformed" in error_text
+
+    with patch("ring5._portfolio.render_portfolio", side_effect=FileNotFoundError("gone")):
+        assert ring5_cli.main(["render", "p", "-o", str(tmp_path)]) == 2
+
+    monkeypatch.setattr(sys, "argv", ["ring5", "doctor"])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with pytest.raises(SystemExit):
+            runpy.run_module("ring5.cli", run_name="__main__")
+
+
+def test_table_io_and_shaper_error_edges(tmp_path: Path) -> None:
+    with patch("ring5.data.pd.read_csv", side_effect=ValueError("bad csv")):
+        with pytest.raises(ring5.DataLoadError, match="bad csv"):
+            ring5.Table.from_csv("bad.csv")
+    table = ring5.Table.from_rows([{"x": 1}])
+    with patch.object(pd.DataFrame, "to_csv", side_effect=OSError("disk")):
+        with pytest.raises(ring5.ExportError, match="disk"):
+            table.to_csv(str(tmp_path / "x.csv"))
+    with pytest.raises(ring5.ColumnNotFoundError):
+        table.apply(lambda frame: frame["missing"])
+    with pytest.raises(ring5.PipelineError, match="transform"):
+        table.apply(lambda _frame: (_ for _ in ()).throw(ValueError("transform")))
+
+
+def test_error_payloads_and_complete_figure_spec() -> None:
+    missing = ring5.MissingStatError(["x"])
+    dependency = ring5.DependencyMissingError("tool", "install it")
+    assert missing.missing == ["x"]
+    assert dependency.binary == "tool" and dependency.install_hint == "install it"
+
+    legend = LegendOpts(
+        position=(0.1, 0.2),
+        anchor=("left", "top"),
+        ncols=2,
+        font_size=9,
+        item_width=4,
+        bgcolor="white",
+        bgalpha=0.5,
+        border_color="black",
+        border_width=1,
+        tracegroupgap=2,
+        column_spacing=0.2,
+        handletextpad=0.3,
+    )
+    spec = FigureSpec(
+        x="x",
+        group="g",
+        y_columns=["y"],
+        x_order=["b", "a"],
+        group_order=["g2", "g1"],
+        legend=legend,
+        dual_axis=DualAxisOpts(columns=["z"], legend=legend),
+    )
+    config = spec.to_config()
+    assert config["xaxis_order"] == ["b", "a"]
+    assert config["group_order"] == ["g2", "g1"]
+    assert config["legend_handletextpad"] == 0.3
+    assert config["dual_legend_handletextpad"] == 0.3
+
+    built = FigureSpecBuilder().title("Title", 12, "serif").bars("stack", 0.1, 0.2, 1).build()
+    assert built.title == "Title" and built.bar_border_width == 1
+
+
+def test_decoration_optional_paths() -> None:
+    fig, ax = plt.subplots()
+    ax.text(0, 0, "other")
+    ax.text(1, 1, "target")
+    ring5.FigureDecorations.tighten_y_ticks(fig)
+    ring5.FigureDecorations.tighten_y_ticks(fig, twin_pad=2)
+    ring5.FigureDecorations.set_twin_ylabel_pad(fig, 3)
+    ring5.FigureDecorations.log_xaxis(fig, ticks=[1, 2])
+    ring5.FigureDecorations.hide_spines(fig, "missing", include_twin=False)
+    ring5.FigureDecorations.hide_spines(fig, "missing", include_twin=True)
+    ring5.FigureDecorations.clamp_bar_xlim(fig)
+    ax.bar([1], [1])
+    ring5.FigureDecorations.clamp_bar_xlim(fig)
+    twin = ax.twinx()
+    setattr(ax, "_ring5_twin", twin)
+    ring5.FigureDecorations.hide_spines(fig, "missing", "top", include_twin=True)
+    ring5.FigureDecorations.nudge_text(fig, "target", 1)
+    ring5.FigureDecorations.over_cap_labels(
+        fig, {}, {"below": 1.0, "missing-coordinate": 3.0}, cap=2.0
+    )
+    plt.close(fig)


### PR DESCRIPTION
## Summary

- complete the public workflow from scan and gem5 parsing through transformations, plotting, rendering, and export
- add scan cancellation, timeouts, partial-result handling, deterministic config-aware metadata, and safe session cleanup
- validate all supported plot mappings before portfolio registration and expose the complete shaper surface
- fix gem5 vector-name and oneline histogram parsing
- document the expanded API and add an exact 100% line-and-branch public API coverage gate

## Why

The Python API did not expose or validate the full application workflow, and several parser edge cases could produce incomplete or incorrect results. Lifecycle behavior around asynchronous scan/parse jobs also allowed temporary resources to be removed while work was active.

## Impact

API consumers can now use the complete analysis workflow programmatically, with typed failures and deterministic lifecycle behavior. All nine supported plot configurations are covered through both rendering engines, and gem5 vector, histogram, and config-aware inputs are handled end to end.

## Validation

- public API suite: 132 passed; 100% line and branch coverage for `ring5`
- full CI: 3,722 passed, 1 skipped; 85.19% combined coverage
- parser-focused suite: 24 passed
- Plotly export suite: 22 passed
- PGF/LaTeX export suite: 5 passed
- formatting, flake8, mypy, architecture, public-docstring, and documentation checks passed
